### PR TITLE
Add generate-inventory-from-netbox script

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,8 +12,10 @@ ENV TZ=UTC
 COPY files/crontab /etc/crontabs/dragon
 COPY files/entrypoint.sh /entrypoint.sh
 COPY files/handle-inventory-overwrite.py /handle-inventory-overwrite.py
+COPY files/generate-inventory-from-netbox.py /generate-inventory-from-netbox.py
 COPY files/requirements.txt /requirements.txt
 COPY files/run.sh /run.sh
+COPY files/templates /templates
 COPY files/sync-inventory-with-netbox.sh /sync-inventory-with-netbox.sh
 COPY files/ansible /ansible
 

--- a/files/generate-inventory-from-netbox.py
+++ b/files/generate-inventory-from-netbox.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# This script reads all required systems from the Netbox and writes them
+# into a form that can be evaluated by the Ansible Inventory Plugin INI. 
+#
+# This is a workaround to use the groups defined in cfg-generics without
+# having to import them into Netbox.
+
+import os
+
+import pynetbox
+
+
+# Read secret from file
+def read_secret(secret_name):
+    try:
+        f = open('/run/secrets/' + secret_name, 'r', encoding='utf-8')
+    except EnvironmentError:
+        return ''
+    else:
+        with f:
+            return f.readline().strip()
+
+
+NETBOX_URL = os.getenv("NETBOX_API")
+NETBOX_TOKEN = os.getenv("NETBOX_TOKEN", read_secret("NETBOX_TOKEN"))
+IGNORE_SSL_ERRORS = (os.getenv("IGNORE_SSL_ERRORS", "True") == "True")
+
+nb = pynetbox.api(
+    NETBOX_URL,
+    NETBOX_TOKEN
+)
+
+if IGNORE_SSL_ERRORS:
+    import requests
+    requests.packages.urllib3.disable_warnings()
+    session = requests.Session()
+    session.verify = False
+    nb.http_session = session
+
+devices = nb.dcim.devices.filter(
+    tag=["managed-by-bifrost", "managed-by-osism"],
+    status="active",
+    cf_device_type=["server"],
+    cf_provisioning_state=["active"]
+)
+
+devices_to_tags = {}
+
+for device in devices:
+    for tag in device.tags:
+        if not tag.slug in devices_to_tags:
+            devices_to_tags[tag.slug] = []
+        devices_to_tags[tag.slug].append(device)
+
+data = {
+    "devices_to_tags": devices_to_tags
+}
+
+loader = jinja2.FileSystemLoader(searchpath="/templates/")
+environment = jinja2.Environment(loader=loader)
+template = environment.get_template("netbox.hosts.j2")
+result = template.render(data)
+
+with open(f"/inventory.pre/netbox.hosts", "w+") as fp:
+    fp.write(os.linesep.join([s for s in result.splitlines() if s]))
+
+for tag in devices_to_tags:
+    print(f"[{tag}]")
+
+    for device in devices_to_tags[tag]:
+        print(f"{device}")
+
+    print("\n")

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,3 +1,4 @@
+Jinja2==3.0.3
 ansible-runner==2.0.3
 ansible>=3.0.0,<4.0.0
 celery[redis]==5.2.0

--- a/files/run.sh
+++ b/files/run.sh
@@ -9,6 +9,10 @@ rsync -a /inventory.generics/ /inventory.pre/
 rsync -a /extra/ //inventory.pre/
 rsync -a /opt/configuration/inventory/ /inventory.pre/
 
+if [[ -e /run/secrets/NETBOX_TOKEN ]]; then
+    python3 /generate-inventory-from-netbox.py
+fi
+
 python3 /handle-inventory-overwrite.py
 
 cat /inventory.pre/[0-9]* > /inventory.pre/hosts

--- a/files/templates/netbox.hosts.j2
+++ b/files/templates/netbox.hosts.j2
@@ -1,0 +1,6 @@
+{% for tag in devices_to_tags %}
+[{{ tag }}]
+{% for device in devices_to_tags[tag] %}
+{{ device }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This script generates an /inventory.pre/netbox.hosts
file in which all hosts defined in the netbox are stored.
The tags assigned to the hosts are used as host groups.

This script is necessary to be able to work with the
inventory defined in cfg-generics without importing it
into Netbox even when Netbox is activated.

One issue that still needs to be fixed is updating the
inventory via the reconciler when changes are made in the
Netbox.

This will be solved later via the python-osism API/Netbox
integration. When changes are made in the Netbox, a webhook
is triggered on the API, which in turn triggers an update
of the inventory.

Signed-off-by: Christian Berendt <berendt@osism.tech>