### PR TITLE
Use versions & overlays provided via /interface

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -11,6 +11,18 @@ rsync -a /inventory.generics/ /inventory.pre/
 rsync -a /extra/ //inventory.pre/
 rsync -a /opt/configuration/inventory/ /inventory.pre/
 
+# get version files from /interface/versions
+cp /interface/versions/osism-ansible.yml /inventory.pre/group_vars/all/100-versions-osism-ansible.yml
+if [[ -e /interface/versions/ceph-ansible.yml ]]; then
+    cp /interface/versions/ceph-ansible.yml /inventory.pre/group_vars/all/100-versions-ceph-ansible.yml
+fi
+if [[ -e /interface/versions/kolla-ansible.yml ]]; then
+    cp /interface/versions/kolla-ansible.yml /inventory.pre/group_vars/all/100-versions-kolla-ansible.yml
+fi
+
+# get overlay files from /interface/overlays
+cp /interface/overlays/kolla-ansible.yml /inventory.pre/group_vars/all/100-overlays-kolla-ansible.yml
+
 if [[ -e /run/secrets/NETBOX_TOKEN ]]; then
     python3 /generate-inventory-from-netbox.py
 fi


### PR DESCRIPTION
The respective active Ansible Runtime Environments
provide the provided versions via /interface. These
are to be used accordingly as default in the inventory.

Signed-off-by: Christian Berendt <berendt@osism.tech>