### PR TITLE
improve reconciler run.sh reliability, and removed redundancy. 

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -47,12 +47,9 @@ if [[ ! -e .git ]]; then
     git init
     git config user.name "Inventory Reconciler"
     git config user.email "inventory@reconciler.local"
-
-    git add -A
-    git commit -m $(date +"%Y-%m-%d-%H-%M")
-else
-    git add -A
-    git commit -m $(date +"%Y-%m-%d-%H-%M")
 fi
+
+git add -A
+git commit -m $(date +"%Y-%m-%d-%H-%M")
 
 popd > /dev/null

--- a/files/run.sh
+++ b/files/run.sh
@@ -8,7 +8,7 @@ ls -1 /opt/configuration/inventory/
 
 rsync -a --exclude README.md --exclude LICENSE --exclude '.*' /defaults/ /inventory.pre/group_vars/
 rsync -a /inventory.generics/ /inventory.pre/
-rsync -a /extra/ //inventory.pre/
+rsync -a /extra/ /inventory.pre/
 rsync -a /opt/configuration/inventory/ /inventory.pre/
 
 # get version files from /interface/versions

--- a/files/run.sh
+++ b/files/run.sh
@@ -41,7 +41,7 @@ fi
 ansible-inventory -i /inventory.pre --list -y --output /inventory.merge/hosts.yml
 rsync -a --delete --exclude .git /inventory.merge/ /inventory
 
-pushd /inventory > /dev/null
+pushd /inventory > /dev/null || exit 1
 
 if [[ ! -e .git ]]; then
     git init


### PR DESCRIPTION

Redundancy: 
[Removed unnessecary slash in rsync target path.](https://github.com/osism/container-image-inventory-reconciler/commit/1115e7d86689298753683814c440dab6cedd5592)
["git add" and "git commit" were double, and always run. So moved outside of if-statement. ](https://github.com/osism/container-image-inventory-reconciler/commit/44db88e0d6a693ff1c81f6132ec830b9d164aa85)

Reliability:
[pushd should exit the script if directory cannot be changed. Otherwise an unexpected directory could be initialized by git. ](https://github.com/osism/container-image-inventory-reconciler/commit/fc586ff4d0985cc63b0fb3f4fc3cf334c83606d6)
 