### PR TITLE
Check first if /etc/environment exists

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source /etc/environment
+if [[ -e /etc/environment ]]; then
+    source /etc/environment
+fi
 
 rm -rf /inventory.pre/*
 


### PR DESCRIPTION
This will resolve the following issue:

/run.sh: line 3: /etc/environment: No such file or directory

Signed-off-by: Christian Berendt <berendt@osism.tech>