### PR TITLE
Use flock to run only one sync-inventory-with-netbox.sh

### DIFF
--- a/files/sync-inventory-with-netbox.sh
+++ b/files/sync-inventory-with-netbox.sh
@@ -4,5 +4,5 @@ source /etc/environment
 export NETBOX_API
 
 if [[ -e /run/secrets/NETBOX_TOKEN ]]; then
-    ansible-playbook -i /inventory /ansible/playbooks/import-netbox.yml
+    flock -n /tmp/sync-inventory-with-netbox.lock -c 'ansible-playbook -i /inventory /ansible/playbooks/import-netbox.yml'
 fi


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>