### PR TITLE
netbox: filter by maintenance & provision state

### DIFF
--- a/files/generate-inventory-from-netbox.py
+++ b/files/generate-inventory-from-netbox.py
@@ -56,12 +56,13 @@ else:
     sys.exit(1)
 
 devices = nb.dcim.devices.filter(
-    tag=["managed-by-bifrost", "managed-by-osism"],
+    tag=["managed-by-osism"],
     status="active",
     cf_deployment_enabled=[True],
     cf_deployment_type=["osism"],
     cf_device_type=["server"],
-    cf_provision_state=["active"]
+    cf_maintenance=[False],
+    cf_provision_state=["active"],
 )
 
 devices_to_tags = {}


### PR DESCRIPTION
Also removes the managed-by-bifrost tag.

Signed-off-by: Christian Berendt <berendt@osism.tech>