### PR TITLE
Revert "Use lockfile instead of flock (#85)"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,6 @@ RUN apk add --no-cache \
       bash \
       git \
       jq \
-      lockfile-progs \
       rsync \
       sudo \
       tini \

--- a/files/sync-inventory-with-netbox.sh
+++ b/files/sync-inventory-with-netbox.sh
@@ -3,23 +3,4 @@
 source /etc/environment
 export NETBOX_API
 
-# NOTE: locking inspired by https://www.baeldung.com/linux/bash-ensure-instance-running
-
-LOCK_FILE=/tmp/sync-inventory-with-netbox.lock
-LOCK_TIMEOUT=300
-
-remove_lock()
-{
-    rm -f "$LOCK_FILE"
-}
-
-another_instance()
-{
-    echo "There is another instance running, exiting"
-    exit 1
-}
-
-lockfile -r 0 -l $LOCK_TIMEOUT "$LOCK_FILE" || another_instance
-trap remove_lock EXIT
-
-ansible-playbook -i /inventory /ansible/playbooks/import-netbox.yml
+flock -n /tmp/sync-inventory-with-netbox.lock -c 'ansible-playbook -i /inventory /ansible/playbooks/import-netbox.yml'


### PR DESCRIPTION
Does not work like expected.

This reverts commit 48114f328075a9f0f48a9947969483060e6ebe3f.

Signed-off-by: Christian Berendt <berendt@osism.tech>