### PR TITLE
Remove ansible-runner from requirements

### DIFF
--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,8 +1,5 @@
 Jinja2==3.1.2
 ansible-core==2.13.7
-ansible-runner==2.3.1
-celery[redis]==5.2.7
 netaddr==0.8.0
 osism==0.9.4
-pynetbox==7.0.1
 yq==3.1.0


### PR DESCRIPTION
Will be installed when required in the future via python-osism.

Signed-off-by: Christian Berendt <berendt@osism.tech>