### PR TITLE
Ignore dotfiles in /inventory

### DIFF
--- a/files/handle-inventory-overwrite.py
+++ b/files/handle-inventory-overwrite.py
@@ -34,7 +34,7 @@ for section in config.sections():
     sections.append(section)
 
 for f in os.scandir(dirname):
-    if f.is_file() and not f.path.endswith(filename):
+    if f.is_file() and not f.path.endswith(filename) and not f.name.startswith("."):
         changed = False
 
         config = configparser.ConfigParser(allow_no_value=True, delimiters="=")

--- a/files/run.sh
+++ b/files/run.sh
@@ -28,7 +28,7 @@ rm -rf /inventory.pre/*
 rsync -q -a --exclude README.md --exclude LICENSE --exclude '.*' /defaults/ /inventory.pre/group_vars/
 rsync -q -a /inventory.generics/ /inventory.pre/
 rsync -q -a /extra/ /inventory.pre/
-rsync -q -a /opt/configuration/inventory/ /inventory.pre/
+rsync -q -a --exclude '.*' /opt/configuration/inventory/ /inventory.pre/
 
 # get version files from /interface/versions
 if [[ -e /interface/versions/osism-ansible.yml ]]; then


### PR DESCRIPTION
This will avoid issues when editing files with vi or similar tools in the configuration repository on the manager.

Related to osism/issues#780