### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS-667eb2130ec3e901.yaml
+++ b/releasenotes/notes/ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS-667eb2130ec3e901.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Set `ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=ignore` to ignore the
-    `[WARNING]: Invalid characters were found in group names but not replaced`
-    message.

--- a/releasenotes/notes/change-osism-4cd904cc80b42d7f.yaml
+++ b/releasenotes/notes/change-osism-4cd904cc80b42d7f.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `change-osism.sh` script it is possible to install a different
-    python-osism version in a running inventory reconciler service.

--- a/releasenotes/notes/multistage-build-03891f02cd36f766.yaml
+++ b/releasenotes/notes/multistage-build-03891f02cd36f766.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Use multi-stage build.

--- a/releasenotes/notes/on-change-0b31169ef1adcf55.yaml
+++ b/releasenotes/notes/on-change-0b31169ef1adcf55.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    The reconciler now has a mode to check in advance for changes in /opt/configuration.
-    If there are no changes, the execution is terminated.

--- a/releasenotes/notes/only-commit-on-changes-c12b10376ed13c71.yaml
+++ b/releasenotes/notes/only-commit-on-changes-c12b10376ed13c71.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Only commit on changes in `/inventory`. This will avoid a RC of 1 when nothing changed.

--- a/releasenotes/notes/prepare-vars-b0e8b404d0017074.yaml
+++ b/releasenotes/notes/prepare-vars-b0e8b404d0017074.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Various variables with useful defaults are now prepared. These can be overwritten
-    in the configuration repository. The variables `ceph_rgw_hosts` and `cephclient_mons`
-    are currently supported.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.