### PR TITLE
Ignore all Python UserWarnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -103,6 +103,8 @@ FROM python:3.12-alpine
 
 COPY --link --from=builder / /
 
+ENV PYTHONWARNINGS="ignore::UserWarning"
+
 USER dragon
 
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
It looks like this is the only way to get rid of the CryptographyDeprecationWarning warnings.