### PR TITLE
Do not handle YAML files with handle-inventory-overwrite.py

### DIFF
--- a/files/handle-inventory-overwrite.py
+++ b/files/handle-inventory-overwrite.py
@@ -34,7 +34,13 @@ for section in config.sections():
     sections.append(section)
 
 for f in os.scandir(dirname):
-    if f.is_file() and not f.path.endswith(filename) and not f.name.startswith("."):
+    if (
+        f.is_file()
+        and not f.path.endswith(filename)
+        and not f.name.startswith(".")
+        and not f.name.endswith(".yml")
+        and not f.name.endswith(".yaml")
+    ):
         changed = False
 
         config = configparser.ConfigParser(allow_no_value=True, delimiters="=")


### PR DESCRIPTION
At the moment we only support INI inventory files. Ignore all YAML inventory files.