### PR TITLE
account for broken/incomplete git configs

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -68,9 +68,14 @@ rsync -q -a --delete --exclude .git /inventory.merge/ /inventory
 
 pushd /inventory > /dev/null || exit 1
 
-if [[ ! -e .git ]]; then
+# check if we are in a git repository
+if git -C . rev-parse 2> /dev/null ; then
     git init
     git config user.name "Inventory Reconciler"
+    git config user.email "inventory@reconciler.local"
+elif [[ -z "$(git config --get user.name)"  ]]; then
+    git config user.name "Inventory Reconciler"
+elif [[ -z "$(git config --get user.email)"  ]]; then
     git config user.email "inventory@reconciler.local"
 fi
 


### PR DESCRIPTION
even if we have a git repository it might be the git config
is incomplete, check each entry and set it if it isn't already.

also use a more canonical way to check for a git repository

Signed-off-by: Sven Kieske <kieske@osism.tech>