### PR TITLE
Prevent roles in 20-roles and 20-netbox to be removed

### DIFF
--- a/files/generate-inventory-from-netbox.py
+++ b/files/generate-inventory-from-netbox.py
@@ -116,6 +116,6 @@ environment = jinja2.Environment(loader=loader)
 template = environment.get_template("netbox.hosts.j2")
 result = template.render(data)
 
-logger.info("Writing host groups from Netbox in the file /inventory.pre/99-netbox")
-with open("/inventory.pre/99-netbox", "w+") as fp:
+logger.info("Writing host groups from Netbox in the file /inventory.pre/20-netbox")
+with open("/inventory.pre/20-netbox", "w+") as fp:
     fp.write(os.linesep.join([s for s in result.splitlines() if s]))

--- a/files/handle-inventory-overwrite.py
+++ b/files/handle-inventory-overwrite.py
@@ -48,6 +48,8 @@ def handle_overwrite_file(filename, dirname="/inventory.pre/"):
         if (
             f.is_file()
             and not f.path.endswith(filename)
+            and not f.path.endswith("20-roles")
+            and not f.path.endswith("20-netbox")
             and not f.path.endswith("99-overwrite")
             and not f.name.startswith(".")
             and not f.name.endswith(".yml")

--- a/files/handle-inventory-overwrite.py
+++ b/files/handle-inventory-overwrite.py
@@ -75,5 +75,5 @@ def handle_overwrite_file(filename, dirname="/inventory.pre/"):
 
 if __name__ == "__main__":
     handle_overwrite_file("99-overwrite")
-    handle_overwrite_file("99-netbox")
+    handle_overwrite_file("20-netbox")
     handle_overwrite_file("20-roles")


### PR DESCRIPTION
As with the new version, roles defined in 20-roles, 20-netbox and 99-override will be removed from any other file. This is obviously useful for generics, but not when you have two inventory sources (from repo and netbox). 

In our case we define the manager (where netbox is deployed) in the repo, and everything else in git. The 'generic' group is then removed from the repo inventory.

I think it's fair to say we can ignore 20-roles and 20-netbox and keep them as is, as both of these sources are controlled by the user (unlike the config generics)