### PR TITLE
Add OSISM_LOG_LEVEL environment variable support to all Python scripts

### DIFF
--- a/files/generate-clustershell-ansible-file.py
+++ b/files/generate-clustershell-ansible-file.py
@@ -3,6 +3,7 @@
 
 """Generate ClusterShell configuration file from Ansible inventory."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -13,7 +14,7 @@ import yaml
 
 
 # Configure logging
-LOG_LEVEL = "INFO"
+LOG_LEVEL = os.getenv("OSISM_LOG_LEVEL", "INFO")
 LOG_FORMAT = (
     "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | "
     "<level>{message}</level>"

--- a/files/generate-inventory-from-netbox.py
+++ b/files/generate-inventory-from-netbox.py
@@ -197,7 +197,7 @@ class InventoryManager:
 
 def setup_logging() -> None:
     """Configure logging settings."""
-    level = "INFO"
+    level = os.getenv("OSISM_LOG_LEVEL", "INFO")
     log_fmt = (
         "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | "
         "<level>{message}</level>"

--- a/files/handle-inventory-overwrite.py
+++ b/files/handle-inventory-overwrite.py
@@ -32,7 +32,12 @@ LOGGER_FORMAT = (
     "<level>{message}</level>"
 )
 logger.remove()
-logger.add(sys.stdout, format=LOGGER_FORMAT, level="INFO", colorize=True)
+logger.add(
+    sys.stdout,
+    format=LOGGER_FORMAT,
+    level=os.getenv("OSISM_LOG_LEVEL", "INFO"),
+    colorize=True,
+)
 
 
 def get_section_variants(section: str) -> List[str]:

--- a/files/merge-ansible-cfg.py
+++ b/files/merge-ansible-cfg.py
@@ -9,6 +9,7 @@ to the inventory directory. The user configuration takes precedence over default
 """
 
 import configparser
+import os
 import sys
 from pathlib import Path
 from typing import List, Optional
@@ -26,7 +27,12 @@ LOGGER_FORMAT = (
     "<level>{message}</level>"
 )
 logger.remove()
-logger.add(sys.stdout, format=LOGGER_FORMAT, level="INFO", colorize=True)
+logger.add(
+    sys.stdout,
+    format=LOGGER_FORMAT,
+    level=os.getenv("OSISM_LOG_LEVEL", "INFO"),
+    colorize=True,
+)
 
 
 def validate_config_files(config_paths: List[str]) -> List[str]:

--- a/files/merge-inventory-files.py
+++ b/files/merge-inventory-files.py
@@ -10,6 +10,7 @@ content taking precedence.
 """
 
 import configparser
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -26,7 +27,12 @@ LOGGER_FORMAT = (
     "<level>{message}</level>"
 )
 logger.remove()
-logger.add(sys.stdout, format=LOGGER_FORMAT, level="INFO", colorize=True)
+logger.add(
+    sys.stdout,
+    format=LOGGER_FORMAT,
+    level=os.getenv("OSISM_LOG_LEVEL", "INFO"),
+    colorize=True,
+)
 
 
 def read_config_file(filepath: Path) -> Optional[configparser.ConfigParser]:

--- a/files/move-group-vars.py
+++ b/files/move-group-vars.py
@@ -26,7 +26,12 @@ LOGGER_FORMAT = (
     "<level>{message}</level>"
 )
 logger.remove()
-logger.add(sys.stdout, format=LOGGER_FORMAT, level="INFO", colorize=True)
+logger.add(
+    sys.stdout,
+    format=LOGGER_FORMAT,
+    level=os.getenv("OSISM_LOG_LEVEL", "INFO"),
+    colorize=True,
+)
 
 
 def validate_directory(dir_path: str) -> bool:

--- a/files/prepare-vars.py
+++ b/files/prepare-vars.py
@@ -9,6 +9,7 @@ This script generates specific Ansible variable files based on the inventory gro
 - Ceph cluster FSID from configuration
 """
 
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -42,7 +43,12 @@ LOGGER_FORMAT = (
     "<level>{message}</level>"
 )
 logger.remove()
-logger.add(sys.stdout, format=LOGGER_FORMAT, level="INFO", colorize=True)
+logger.add(
+    sys.stdout,
+    format=LOGGER_FORMAT,
+    level=os.getenv("OSISM_LOG_LEVEL", "INFO"),
+    colorize=True,
+)
 
 
 def write_yaml_file(file_path: Path, data: Dict[str, Any]) -> bool:


### PR DESCRIPTION
Allow configuring the log level via the OSISM_LOG_LEVEL environment variable in all Python scripts in the files directory. This provides consistent logging configuration across all inventory reconciler components. The default log level remains INFO if the environment variable is not set.

AI-assisted: Claude Code