### PR TITLE
netbox: add dnsmasq_dhcp_macs parameter

### DIFF
--- a/files/generate-inventory-from-netbox.py
+++ b/files/generate-inventory-from-netbox.py
@@ -371,7 +371,17 @@ class InventoryManager:
                 logger.debug(f"Added dnsmasq entry for {device.name}: {entry}")
 
                 # Create the dnsmasq configuration data
-                dnsmasq_data = {f"_dnsmasq_dhcp_hosts__{device.name}": [entry]}
+                dnsmasq_data = {f"dnsmasq_dhcp_hosts__{device.name}": [entry]}
+
+                # Add dnsmasq_dhcp_macs using device type slug
+                if device.device_type and device.device_type.slug:
+                    device_type_slug = device.device_type.slug
+                    # Format: dhcp-mac=tag:device-type-slug,mac-address
+                    mac_entry = f"tag:{device_type_slug},{mac_formatted}"
+                    dnsmasq_data[f"dnsmasq_dhcp_macs__{device.name}"] = [mac_entry]
+                    logger.debug(
+                        f"Added dnsmasq MAC entry for {device.name}: {mac_entry}"
+                    )
 
                 # Determine base path for device files
                 host_vars_path = self.config.inventory_path / "host_vars"


### PR DESCRIPTION
- Generate dnsmasq DHCP MAC tags based on device type slugs
- Format entries as "tag:device-type-slug,mac-address"
- Enables device type-based DHCP configuration in dnsmasq

AI-assisted: Claude Code