### PR TITLE
netbox: use device roles instead of tags for group assignment

### DIFF
--- a/files/templates/netbox.hosts.j2
+++ b/files/templates/netbox.hosts.j2
@@ -1,6 +1,6 @@
-{% for tag in devices_to_tags %}
-[{{ tag }}]
-{% for device in devices_to_tags[tag] %}
+{% for group, devices in devices_to_roles.items() %}
+[{{ group }}]
+{% for device in devices %}
 {{ device }}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
This change modifies the NetBox inventory generation to:
1. Use device roles instead of tags to assign devices to Ansible groups
2. Allow configuring multiple groups per device role via ROLE_MAPPING_<ROLE> env vars
3. Add NETBOX_IGNORED_ROLES for excluding specific device roles
4. Ensure devices have managed-by-osism tag to be considered for inventory

Example: Devices with role "compute" will be assigned to group "generic" by default, but can be customized via ROLE_MAPPING_COMPUTE env var.

AI-assisted: Claude Code