### PR TITLE
netbox: add configurable device filtering

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -36,15 +36,21 @@ This NetBox module is part of the OSISM Container Image Inventory Reconciler. It
 - `NETBOX_DATA_TYPES` - Comma-separated data types to extract (default: "primary_ip,config_context")
 - `NETBOX_IGNORED_ROLES` - Device roles to skip (default: "housing,pdu,other,oob")
 - `NETBOX_ROLE_MAPPING` - JSON mapping of device roles to inventory groups
+- `NETBOX_FILTER_INVENTORY` - JSON filter for device selection (default: `{"status": "active", "tag": "managed-by-osism"}`)
 - `IGNORE_SSL_ERRORS` - Skip SSL verification (default: true)
 - `INVENTORY_PATH` - Output path for inventory files (default: "/inventory.pre")
 
 ## Device Selection Logic
 
 ### Devices are selected if:
-- Tagged with "managed-by-osism" AND status is "active"
+- They match the filter criteria specified in `NETBOX_FILTER_INVENTORY` (default: status="active" AND tag="managed-by-osism")
 - NOT in maintenance mode (custom field)
 - For devices also tagged with "managed-by-ironic": provision_state must be "active"
+
+### Custom Filter Examples
+- Filter by specific device type: `{"status": "active", "tag": "managed-by-osism", "device_type": "server"}`
+- Filter by site: `{"status": "active", "tag": "managed-by-osism", "site": "datacenter-1"}`
+- Filter by multiple tags: `{"status": "active", "tag": ["managed-by-osism", "production"]}`
 
 ### Role Mapping
 Devices are assigned to Ansible groups based on their NetBox role:

--- a/files/netbox/config.py
+++ b/files/netbox/config.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Any
 
 from dynaconf import Dynaconf
 
@@ -30,6 +30,7 @@ class Config:
     template_path: Path = Path("/netbox/templates/")
     data_types: List[str] = None  # Configurable data types to extract
     ignored_roles: List[str] = None  # Device roles to ignore
+    filter_inventory: Dict[str, Any] = None  # Custom filter for device selection
 
     @classmethod
     def from_environment(cls) -> "Config":
@@ -54,6 +55,12 @@ class Config:
         # Ensure lowercase for consistency
         ignored_roles = [role.lower() for role in ignored_roles]
 
+        # Get filter inventory from dynaconf
+        # Default: devices with state=active and tag=managed-by-osism
+        filter_inventory = SETTINGS.get(
+            "NETBOX_FILTER_INVENTORY", {"status": "active", "tag": "managed-by-osism"}
+        )
+
         return cls(
             netbox_url=netbox_url,
             netbox_token=netbox_token,
@@ -62,6 +69,7 @@ class Config:
             template_path=Path(SETTINGS.get("TEMPLATE_PATH", "/netbox/templates/")),
             data_types=data_types,
             ignored_roles=ignored_roles,
+            filter_inventory=filter_inventory,
         )
 
     @staticmethod


### PR DESCRIPTION
Allow custom NetBox device filters via NETBOX_FILTER_INVENTORY environment variable. This enables flexible device selection based on status, tags, device type, site, or other NetBox attributes while maintaining backward compatibility with the default filter.

AI-assisted: Claude Code