### PR TITLE
netbox: add support for multiple device filters in NETBOX_FILTER_INVE…

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -48,9 +48,12 @@ This NetBox module is part of the OSISM Container Image Inventory Reconciler. It
 - For devices also tagged with "managed-by-ironic": provision_state must be "active"
 
 ### Custom Filter Examples
-- Filter by specific device type: `{"status": "active", "tag": "managed-by-osism", "device_type": "server"}`
+- Single filter (dictionary): `{"status": "active", "tag": "managed-by-osism", "device_type": "server"}`
 - Filter by site: `{"status": "active", "tag": "managed-by-osism", "site": "datacenter-1"}`
 - Filter by multiple tags: `{"status": "active", "tag": ["managed-by-osism", "production"]}`
+- Multiple filters (list of dictionaries): `[{"status": "active", "tag": "managed-by-osism", "site": "dc1"}, {"status": "active", "tag": "managed-by-osism", "site": "dc2"}]`
+  - When using a list, devices matching ANY filter will be included (OR operation)
+  - Duplicate devices are automatically removed
 
 ### Role Mapping
 Devices are assigned to Ansible groups based on their NetBox role:

--- a/files/netbox/config.py
+++ b/files/netbox/config.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Union
 
 from dynaconf import Dynaconf
 
@@ -30,7 +30,9 @@ class Config:
     template_path: Path = Path("/netbox/templates/")
     data_types: List[str] = None  # Configurable data types to extract
     ignored_roles: List[str] = None  # Device roles to ignore
-    filter_inventory: Dict[str, Any] = None  # Custom filter for device selection
+    filter_inventory: Union[Dict[str, Any], List[Dict[str, Any]]] = (
+        None  # Custom filter(s) for device selection
+    )
 
     @classmethod
     def from_environment(cls) -> "Config":


### PR DESCRIPTION
…NTORY

Allow NETBOX_FILTER_INVENTORY to accept either a single filter dictionary (for backwards compatibility) or a list of filter dictionaries. When multiple filters are provided, devices matching ANY filter are included (OR operation), with automatic duplicate removal based on device ID.

This enables more flexible device selection across multiple sites, device types, or other criteria without requiring complex single filters.

Example usage:
- Single filter: {"status": "active", "tag": "managed-by-osism"}
- Multiple filters: [{"site": "dc1"}, {"site": "dc2"}]

AI-assisted: Claude Code