### PR TITLE
netbox: fix interface fetching in netplan extractor to use API filters

### DIFF
--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -15,12 +15,16 @@ from extractors import (
 class DeviceDataExtractor:
     """Extracts various data fields from NetBox devices."""
 
-    def __init__(self):
-        """Initialize extractors."""
+    def __init__(self, api=None):
+        """Initialize extractors.
+
+        Args:
+            api: NetBox API instance (required for NetplanExtractor)
+        """
         self.config_context_extractor = ConfigContextExtractor()
         self.primary_ip_extractor = PrimaryIPExtractor()
         self.custom_field_extractor = CustomFieldExtractor()
-        self.netplan_extractor = NetplanExtractor()
+        self.netplan_extractor = NetplanExtractor(api=api)
 
     def extract_config_context(self, device: Any) -> Dict[str, Any]:
         """Extract config context from device."""

--- a/files/netbox/inventory_manager.py
+++ b/files/netbox/inventory_manager.py
@@ -16,9 +16,9 @@ from data_extractor import DeviceDataExtractor
 class InventoryManager:
     """Manages inventory file operations."""
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, api=None):
         self.config = config
-        self.data_extractor = DeviceDataExtractor()
+        self.data_extractor = DeviceDataExtractor(api=api)
         self.jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(searchpath=str(config.template_path))
         )

--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -33,7 +33,7 @@ def main() -> None:
 
         # Initialize components
         netbox_client = NetBoxClient(config)
-        inventory_manager = InventoryManager(config)
+        inventory_manager = InventoryManager(config, api=netbox_client.api)
         dnsmasq_manager = DnsmasqManager(config)
 
         # Fetch devices


### PR DESCRIPTION
Replace device.interfaces.all() with proper API filtering by device_id as the former doesn't work correctly with pynetbox. Also fixes IP address fetching for dummy0 interfaces to use API filters. The NetBox API instance is now passed through the initialization chain from main.py to NetplanExtractor.

AI-assisted: Claude Code