### PR TITLE
netbox: require parent interface tag for VLAN configuration

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -86,6 +86,7 @@ The `999-netbox-netplan.yml` file contains netplan_parameters which can be:
     - All IPv4 and IPv6 addresses assigned to it are included
     - The interface is listed in `network_dummy_interfaces`
   - **VLAN interfaces**: Virtual interfaces (type=virtual) with the tag, untagged VLAN and parent interface
+    - Both the VLAN interface AND its parent interface must have the `managed-by-osism` tag
     - The label (or name if no label) becomes the VLAN interface name
     - The VLAN ID is extracted from the untagged VLAN
     - The parent interface's label (or name) is used as the link

--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -33,6 +33,7 @@ class NetplanExtractor(BaseExtractor):
         - Must have "managed-by-osism" tag
         - Must have an untagged VLAN assigned
         - Must have a parent interface
+        - Parent interface must also have "managed-by-osism" tag
 
         Args:
             device: NetBox device object
@@ -87,6 +88,18 @@ class NetplanExtractor(BaseExtractor):
                 # Check if interface has untagged VLAN and parent interface
                 if hasattr(interface, "untagged_vlan") and interface.untagged_vlan:
                     if hasattr(interface, "parent") and interface.parent:
+                        # Check if parent interface also has managed-by-osism tag
+                        parent_has_tag = False
+                        if hasattr(interface.parent, "tags") and interface.parent.tags:
+                            parent_tag_slugs = [
+                                tag.slug for tag in interface.parent.tags
+                            ]
+                            parent_has_tag = "managed-by-osism" in parent_tag_slugs
+
+                        # Only include VLAN if parent also has the tag
+                        if not parent_has_tag:
+                            continue
+
                         vlan_name = (
                             interface.label if interface.label else interface.name
                         )


### PR DESCRIPTION
Add validation to ensure VLAN interfaces are only included in netplan configuration when both the virtual interface and its parent interface have the managed-by-osism tag. This prevents VLANs from being configured on unmanaged parent interfaces.

AI-assisted: Claude Code