### PR TITLE
netbox: add consolidated dnsmasq configuration for metalbox mode

### DIFF
--- a/files/netbox/dnsmasq_manager.py
+++ b/files/netbox/dnsmasq_manager.py
@@ -19,9 +19,79 @@ class DnsmasqManager:
         self.config = config
 
     def write_dnsmasq_config(
-        self, netbox_client: NetBoxClient, devices: List[Any]
+        self,
+        netbox_client: NetBoxClient,
+        devices: List[Any],
+        all_devices: List[Any] = None,
     ) -> None:
-        """Write dnsmasq DHCP configuration for devices with OOB management interfaces."""
+        """Write dnsmasq DHCP configuration for devices with OOB management interfaces.
+
+        Args:
+            netbox_client: NetBox API client
+            devices: List of devices to write configurations for
+            all_devices: List of all devices (used in metalbox mode to collect all OOB configs)
+        """
+        # In metalbox mode, collect all dnsmasq entries to write to metalbox device
+        if self.config.reconciler_mode == "metalbox" and all_devices:
+            # Collect all dnsmasq entries from all devices
+            all_dhcp_hosts = []
+            all_dhcp_macs = []
+
+            for device in all_devices:
+                logger.debug(f"Collecting OOB interface for device {device}")
+                ip_address, mac_address = netbox_client.get_device_oob_interface(device)
+
+                if ip_address and mac_address:
+                    # Format MAC address properly (lowercase with colons)
+                    mac_formatted = mac_address.lower()
+                    # Create dnsmasq DHCP host entry: "mac,hostname,ip"
+                    host_entry = f"{mac_formatted},{device.name},{ip_address}"
+                    all_dhcp_hosts.append(host_entry)
+                    logger.debug(
+                        f"Collected dnsmasq entry for {device.name}: {host_entry}"
+                    )
+
+                    # Add dnsmasq_dhcp_macs using custom field or device type slug
+                    custom_dhcp_tag = device.custom_fields.get("dnsmasq_dhcp_tag")
+
+                    if custom_dhcp_tag:
+                        # Use custom field value if set
+                        mac_entry = f"tag:{custom_dhcp_tag},{mac_formatted}"
+                        all_dhcp_macs.append(mac_entry)
+                        logger.debug(
+                            f"Collected dnsmasq MAC entry for {device.name} using custom tag: {mac_entry}"
+                        )
+                    elif device.device_type and device.device_type.slug:
+                        # Fallback to device type slug
+                        device_type_slug = device.device_type.slug
+                        # Format: dhcp-mac=tag:device-type-slug,mac-address
+                        mac_entry = f"tag:{device_type_slug},{mac_formatted}"
+                        all_dhcp_macs.append(mac_entry)
+                        logger.debug(
+                            f"Collected dnsmasq MAC entry for {device.name} using device type: {mac_entry}"
+                        )
+
+            # Write collected entries to metalbox device(s)
+            for device in devices:
+                if (
+                    device.role
+                    and device.role.slug
+                    and device.role.slug.lower() == "metalbox"
+                ):
+                    # Create the dnsmasq configuration data with all collected entries
+                    dnsmasq_data = {
+                        "dnsmasq_dhcp_hosts": all_dhcp_hosts,
+                        "dnsmasq_dhcp_macs": all_dhcp_macs,
+                    }
+
+                    # Write to metalbox device's host vars
+                    self._write_dnsmasq_to_device(device, dnsmasq_data)
+                    logger.info(
+                        f"Wrote {len(all_dhcp_hosts)} dnsmasq entries to metalbox device {device.name}"
+                    )
+            return
+
+        # Original behavior for manager mode
         for device in devices:
             logger.debug(f"Checking OOB interface for device {device}")
             ip_address, mac_address = netbox_client.get_device_oob_interface(device)
@@ -56,46 +126,50 @@ class DnsmasqManager:
                         f"Added dnsmasq MAC entry for {device.name} using device type: {mac_entry}"
                     )
 
-                # Determine base path for device files
-                host_vars_path = self.config.inventory_path / "host_vars"
-                device_pattern = f"{device}*"
-                result = list(host_vars_path.glob(device_pattern))
-
-                if len(result) > 1:
-                    logger.warning(
-                        f"Multiple matches found for {device}, skipping dnsmasq writing"
-                    )
-                    continue
-
-                base_path = result[0] if len(result) == 1 else None
-
                 # Write to device-specific file
-                if base_path:
-                    if base_path.is_dir():
-                        output_file = base_path / "999-netbox-dnsmasq.yml"
-                        logger.debug(
-                            f"Writing dnsmasq config for {device} to {output_file}"
-                        )
-                        with open(output_file, "w+", encoding="utf-8") as fp:
-                            yaml.dump(dnsmasq_data, fp, Dumper=yaml.Dumper)
-                    else:
-                        # For existing single file, append with separator
-                        logger.debug(
-                            f"Appending dnsmasq config for {device} to {base_path}"
-                        )
-                        with open(base_path, "a", encoding="utf-8") as fp:
-                            fp.write("\n# NetBox dnsmasq\n")
-                            yaml.dump(dnsmasq_data, fp, Dumper=yaml.Dumper)
-                else:
-                    # Create new directory structure
-                    device_dir = self.config.inventory_path / "host_vars" / str(device)
-                    device_dir.mkdir(parents=True, exist_ok=True)
-                    output_file = device_dir / "999-netbox-dnsmasq.yml"
-                    logger.debug(
-                        f"Writing dnsmasq config for {device} to {output_file}"
-                    )
-                    with open(output_file, "w+", encoding="utf-8") as fp:
-                        yaml.dump(dnsmasq_data, fp, Dumper=yaml.Dumper)
+                self._write_dnsmasq_to_device(device, dnsmasq_data)
+
+    def _write_dnsmasq_to_device(self, device: Any, dnsmasq_data: dict) -> None:
+        """Write dnsmasq configuration data to device's host vars.
+
+        Args:
+            device: The NetBox device object
+            dnsmasq_data: Dictionary containing dnsmasq configuration
+        """
+        # Determine base path for device files
+        host_vars_path = self.config.inventory_path / "host_vars"
+        device_pattern = f"{device}*"
+        result = list(host_vars_path.glob(device_pattern))
+
+        if len(result) > 1:
+            logger.warning(
+                f"Multiple matches found for {device}, skipping dnsmasq writing"
+            )
+            return
+
+        base_path = result[0] if len(result) == 1 else None
+
+        # Write to device-specific file
+        if base_path:
+            if base_path.is_dir():
+                output_file = base_path / "999-netbox-dnsmasq.yml"
+                logger.debug(f"Writing dnsmasq config for {device} to {output_file}")
+                with open(output_file, "w+", encoding="utf-8") as fp:
+                    yaml.dump(dnsmasq_data, fp, Dumper=yaml.Dumper)
+            else:
+                # For existing single file, append with separator
+                logger.debug(f"Appending dnsmasq config for {device} to {base_path}")
+                with open(base_path, "a", encoding="utf-8") as fp:
+                    fp.write("\n# NetBox dnsmasq\n")
+                    yaml.dump(dnsmasq_data, fp, Dumper=yaml.Dumper)
+        else:
+            # Create new directory structure
+            device_dir = self.config.inventory_path / "host_vars" / str(device)
+            device_dir.mkdir(parents=True, exist_ok=True)
+            output_file = device_dir / "999-netbox-dnsmasq.yml"
+            logger.debug(f"Writing dnsmasq config for {device} to {output_file}")
+            with open(output_file, "w+", encoding="utf-8") as fp:
+                yaml.dump(dnsmasq_data, fp, Dumper=yaml.Dumper)
 
     def write_dnsmasq_dhcp_ranges(self, netbox_client: NetBoxClient) -> None:
         """Generate and write dnsmasq DHCP ranges for OOB networks."""

--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -91,7 +91,13 @@ def main() -> None:
 
         # Generate dnsmasq configuration
         logger.info("Generating dnsmasq configuration")
-        dnsmasq_manager.write_dnsmasq_config(netbox_client, inventory_devices)
+        # In metalbox mode, pass all_devices to collect OOB configs from all devices
+        if config.reconciler_mode == "metalbox":
+            dnsmasq_manager.write_dnsmasq_config(
+                netbox_client, inventory_devices, all_devices
+            )
+        else:
+            dnsmasq_manager.write_dnsmasq_config(netbox_client, inventory_devices)
 
         # Generate dnsmasq DHCP ranges
         logger.info("Generating dnsmasq DHCP ranges")


### PR DESCRIPTION
In metalbox mode, collect OOB interface information from all devices and write consolidated dnsmasq_dhcp_hosts and dnsmasq_dhcp_macs parameters to metalbox device host vars. This enables metalbox devices to manage DHCP for the entire infrastructure.

AI-assisted: Claude Code