### PR TITLE
netbox: add support for inventory_hostname custom field

### DIFF
--- a/files/netbox/device_mapping.py
+++ b/files/netbox/device_mapping.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 from loguru import logger
 
 from config import SETTINGS
+from utils import get_inventory_hostname
 
 
 def build_device_tag_mapping(devices: List[Any]) -> Dict[str, List[Any]]:
@@ -26,8 +27,8 @@ def build_device_tag_mapping(devices: List[Any]) -> Dict[str, List[Any]]:
 
 def build_device_role_mapping(
     devices: List[Any], ignored_roles: List[str] = None
-) -> Dict[str, List[Any]]:
-    """Build mapping of roles to devices.
+) -> Dict[str, List[str]]:
+    """Build mapping of roles to device hostnames.
 
     Only includes devices that have the managed-by-osism tag.
     Each device role can be mapped to multiple Ansible inventory groups.
@@ -39,6 +40,9 @@ def build_device_role_mapping(
     Args:
         devices: List of NetBox device objects
         ignored_roles: List of role slugs to skip (default: None)
+
+    Returns:
+        Dictionary mapping group names to lists of device hostnames
     """
     devices_to_groups = {}
 
@@ -81,11 +85,12 @@ def build_device_role_mapping(
             # Default behavior: add to group 'generic'
             groups = ["generic"]
 
-        # Add device to each of its groups
+        # Add device hostname to each of its groups
+        device_hostname = get_inventory_hostname(device)
         for group in groups:
             if group not in devices_to_groups:
                 devices_to_groups[group] = []
-            if device not in devices_to_groups[group]:
-                devices_to_groups[group].append(device)
+            if device_hostname not in devices_to_groups[group]:
+                devices_to_groups[group].append(device_hostname)
 
     return devices_to_groups

--- a/files/netbox/dnsmasq_manager.py
+++ b/files/netbox/dnsmasq_manager.py
@@ -9,6 +9,7 @@ from loguru import logger
 import yaml
 
 from config import Config
+from utils import get_inventory_hostname
 from netbox_client import NetBoxClient
 
 
@@ -44,11 +45,13 @@ class DnsmasqManager:
                 if ip_address and mac_address:
                     # Format MAC address properly (lowercase with colons)
                     mac_formatted = mac_address.lower()
+                    # Get inventory hostname for the device
+                    device_hostname = get_inventory_hostname(device)
                     # Create dnsmasq DHCP host entry: "mac,hostname,ip"
-                    host_entry = f"{mac_formatted},{device.name},{ip_address}"
+                    host_entry = f"{mac_formatted},{device_hostname},{ip_address}"
                     all_dhcp_hosts.append(host_entry)
                     logger.debug(
-                        f"Collected dnsmasq entry for {device.name}: {host_entry}"
+                        f"Collected dnsmasq entry for {device_hostname}: {host_entry}"
                     )
 
                     # Add dnsmasq_dhcp_macs using custom field or device type slug

--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -18,7 +18,7 @@ from device_mapping import build_device_role_mapping
 from dnsmasq_manager import DnsmasqManager
 from inventory_manager import InventoryManager
 from netbox_client import NetBoxClient
-from utils import setup_logging
+from utils import setup_logging, get_inventory_hostname
 
 
 def main() -> None:
@@ -47,7 +47,7 @@ def main() -> None:
         # Extract data for ALL devices (regardless of mode)
         logger.info("Extracting data for all devices")
         for device in all_devices:
-            logger.info(f"Extracting data for {device}")
+            logger.info(f"Extracting data for {get_inventory_hostname(device)}")
             if config.data_types:
                 inventory_manager.extract_device_data(
                     device, data_types=config.data_types
@@ -79,7 +79,7 @@ def main() -> None:
 
         # Write device data files (only for inventory devices)
         for device in inventory_devices:
-            logger.info(f"Writing files for {device}")
+            logger.info(f"Writing files for {get_inventory_hostname(device)}")
             if config.data_types:
                 inventory_manager.write_device_data(
                     device, data_types=config.data_types

--- a/files/netbox/utils.py
+++ b/files/netbox/utils.py
@@ -3,6 +3,7 @@
 """Utility functions for NetBox integration."""
 
 import sys
+from typing import Any
 
 from loguru import logger
 
@@ -18,3 +19,24 @@ def setup_logging() -> None:
     )
     logger.remove()
     logger.add(sys.stdout, format=log_fmt, level=level, colorize=True)
+
+
+def get_inventory_hostname(device: Any) -> str:
+    """Get the inventory hostname for a device.
+
+    If the device has an 'inventory_hostname' custom field set, use that.
+    Otherwise, fall back to the device name.
+
+    Args:
+        device: NetBox device object
+
+    Returns:
+        The hostname to use in the inventory
+    """
+    custom_fields = device.custom_fields or {}
+    inventory_hostname = custom_fields.get("inventory_hostname")
+
+    if inventory_hostname:
+        return str(inventory_hostname)
+
+    return str(device.name)


### PR DESCRIPTION
When the 'inventory_hostname' custom field is set on a NetBox device, use it as the hostname throughout the inventory generation process instead of the device name. This allows flexibility for environments where Ansible inventory hostnames need to differ from NetBox device names.

AI-assisted: Claude Code