### PR TITLE
netbox: cache auto-generated dnsmasq parameters in custom fields

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -140,6 +140,16 @@ The `999-netbox-frr.yml` file contains frr_parameters which can be:
 ### Dnsmasq Files
 - `/inventory.pre/group_vars/manager/999-netbox-dnsmasq.yml` - OOB device configurations
 - `/inventory.pre/group_vars/manager/999-netbox-dnsmasq-dhcp-range.yml` - DHCP ranges
+- `/inventory.pre/host_vars/{device}/999-netbox-dnsmasq.yml` - Cached dnsmasq parameters (if dnsmasq_parameters is in data types)
+
+### Dnsmasq Parameter Caching
+The dnsmasq manager automatically caches generated `dnsmasq_dhcp_hosts` and `dnsmasq_dhcp_macs` parameters in the `dnsmasq_parameters` custom field:
+- **Automatic caching**: When generating dnsmasq configurations, the parameters are cached to the device's custom field
+- **Cache usage**: On subsequent runs, if the `dnsmasq_parameters` custom field exists, its values are used instead of regenerating
+- **Cache format**: The custom field stores a dictionary with:
+  - `dnsmasq_dhcp_hosts`: List of DHCP host entries (format: "mac,hostname,ip")
+  - `dnsmasq_dhcp_macs`: List of MAC entries (format: "tag:tagname,mac")
+- **Data extraction**: Add "dnsmasq_parameters" to NETBOX_DATA_TYPES to extract cached parameters to inventory files
 
 ## Common Development Tasks
 

--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -54,6 +54,12 @@ class DeviceDataExtractor:
             device, local_as_prefix=local_as_prefix, switch_roles=switch_roles
         )
 
+    def extract_dnsmasq_parameters(self, device: Any) -> Any:
+        """Extract dnsmasq parameters from custom field."""
+        return self.custom_field_extractor.extract(
+            device, field_name="dnsmasq_parameters"
+        )
+
     def extract_all_data(
         self,
         device: Any,
@@ -69,4 +75,5 @@ class DeviceDataExtractor:
             "frr_parameters": self.extract_frr_parameters(
                 device, local_as_prefix, switch_roles
             ),
+            "dnsmasq_parameters": self.extract_dnsmasq_parameters(device),
         }

--- a/files/netbox/inventory_manager.py
+++ b/files/netbox/inventory_manager.py
@@ -119,6 +119,9 @@ class InventoryManager:
         elif data_type == "netplan_parameters":
             # For netplan_parameters, write the content directly without wrapper
             content = yaml.dump(data, Dumper=yaml.Dumper)
+        elif data_type == "dnsmasq_parameters":
+            # For dnsmasq_parameters, write the content directly without wrapper
+            content = yaml.dump(data, Dumper=yaml.Dumper)
         else:
             content = yaml.dump(data, Dumper=yaml.Dumper)
 
@@ -128,6 +131,7 @@ class InventoryManager:
             "primary_ip": "999-netbox-ansible.yml",
             "netplan_parameters": "999-netbox-netplan.yml",
             "frr_parameters": "999-netbox-frr.yml",
+            "dnsmasq_parameters": "999-netbox-dnsmasq.yml",
         }
 
         file_suffix = file_suffixes.get(data_type, f"999-netbox-{data_type}.yml")


### PR DESCRIPTION
Implements caching of dnsmasq_dhcp_hosts and dnsmasq_dhcp_macs in the dnsmasq_parameters custom field, following the same pattern as FRR and Netplan parameter caching. This reduces NetBox API calls on subsequent runs by reusing cached values when available.

AI-assisted: Claude Code