### PR TITLE
netbox: add FLUSH_CACHE environment variable to force regeneration of…

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -42,6 +42,7 @@ This NetBox module is part of the OSISM Container Image Inventory Reconciler. It
 - `DEFAULT_MTU` - Default MTU value for interfaces without explicit MTU (default: 9100)
 - `DEFAULT_LOCAL_AS_PREFIX` - Default local AS prefix for FRR configuration (default: 42)
 - `INVENTORY_RECONCILER_MODE` - Operating mode for the reconciler: "manager" or "metalbox" (default: "manager")
+- `FLUSH_CACHE` - Force regeneration of cached custom field values (default: false)
 
 ## Device Selection Logic
 
@@ -150,6 +151,15 @@ The dnsmasq manager automatically caches generated `dnsmasq_dhcp_hosts` and `dns
   - `dnsmasq_dhcp_hosts`: List of DHCP host entries (format: "mac,hostname,ip")
   - `dnsmasq_dhcp_macs`: List of MAC entries (format: "tag:tagname,mac")
 - **Data extraction**: Add "dnsmasq_parameters" to NETBOX_DATA_TYPES to extract cached parameters to inventory files
+
+### Cache Management
+The `FLUSH_CACHE` environment variable controls cache behavior for all auto-generated parameters:
+- **When `FLUSH_CACHE=true`**: Existing cached values in custom fields (`netplan_parameters`, `frr_parameters`, `dnsmasq_parameters`) are ignored and regenerated
+- **When `FLUSH_CACHE=false` (default)**: Cached values are used if they exist, avoiding regeneration
+- **Use cases**: Set `FLUSH_CACHE=true` when:
+  - Network topology has changed
+  - Interface configurations have been updated
+  - You need to force recalculation of all auto-generated parameters
 
 ## Common Development Tasks
 

--- a/files/netbox/config.py
+++ b/files/netbox/config.py
@@ -55,6 +55,7 @@ class Config:
         default_local_as_prefix: Default local AS prefix for FRR configuration
         frr_switch_roles: Device roles considered as switches for FRR uplinks
         reconciler_mode: Operating mode for the reconciler (manager or metalbox)
+        flush_cache: Force regeneration of cached custom field values
     """
 
     netbox_url: str
@@ -77,6 +78,7 @@ class Config:
         default_factory=lambda: DEFAULT_FRR_SWITCH_ROLES.copy()
     )
     reconciler_mode: str = DEFAULT_RECONCILER_MODE
+    flush_cache: bool = False
 
     @classmethod
     def from_environment(cls) -> "Config":
@@ -134,6 +136,7 @@ class Config:
             ),
             frr_switch_roles=SETTINGS.get("FRR_SWITCH_ROLES", DEFAULT_FRR_SWITCH_ROLES),
             reconciler_mode=reconciler_mode,
+            flush_cache=SETTINGS.get("FLUSH_CACHE", False),
         )
 
     @staticmethod

--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -42,16 +42,27 @@ class DeviceDataExtractor:
         """Extract primary IP address from device, prioritizing IPv4 over IPv6."""
         return self.primary_ip_extractor.extract(device)
 
-    def extract_netplan_parameters(self, device: Any, default_mtu: int = 9100) -> Any:
+    def extract_netplan_parameters(
+        self, device: Any, default_mtu: int = 9100, flush_cache: bool = False
+    ) -> Any:
         """Extract netplan parameters, combining manual and auto-generated config."""
-        return self.netplan_extractor.extract(device, default_mtu=default_mtu)
+        return self.netplan_extractor.extract(
+            device, default_mtu=default_mtu, flush_cache=flush_cache
+        )
 
     def extract_frr_parameters(
-        self, device: Any, local_as_prefix: int = 42, switch_roles: List[str] = None
+        self,
+        device: Any,
+        local_as_prefix: int = 42,
+        switch_roles: List[str] = None,
+        flush_cache: bool = False,
     ) -> Any:
         """Extract FRR parameters, combining manual and auto-generated config."""
         return self.frr_extractor.extract(
-            device, local_as_prefix=local_as_prefix, switch_roles=switch_roles
+            device,
+            local_as_prefix=local_as_prefix,
+            switch_roles=switch_roles,
+            flush_cache=flush_cache,
         )
 
     def extract_dnsmasq_parameters(self, device: Any) -> Any:
@@ -66,14 +77,17 @@ class DeviceDataExtractor:
         default_mtu: int = 9100,
         local_as_prefix: int = 42,
         switch_roles: List[str] = None,
+        flush_cache: bool = False,
     ) -> Dict[str, Any]:
         """Extract all configured data types from a device."""
         return {
             "config_context": self.extract_config_context(device),
             "primary_ip": self.extract_primary_ip(device),
-            "netplan_parameters": self.extract_netplan_parameters(device, default_mtu),
+            "netplan_parameters": self.extract_netplan_parameters(
+                device, default_mtu, flush_cache
+            ),
             "frr_parameters": self.extract_frr_parameters(
-                device, local_as_prefix, switch_roles
+                device, local_as_prefix, switch_roles, flush_cache
             ),
             "dnsmasq_parameters": self.extract_dnsmasq_parameters(device),
         }

--- a/files/netbox/dnsmasq_manager.py
+++ b/files/netbox/dnsmasq_manager.py
@@ -24,6 +24,7 @@ class DnsmasqManager:
         netbox_client: NetBoxClient,
         devices: List[Any],
         all_devices: List[Any] = None,
+        flush_cache: bool = False,
     ) -> None:
         """Write dnsmasq DHCP configuration for devices with OOB management interfaces.
 
@@ -31,6 +32,7 @@ class DnsmasqManager:
             netbox_client: NetBox API client
             devices: List of devices to write configurations for
             all_devices: List of all devices (used in metalbox mode to collect all OOB configs)
+            flush_cache: Force regeneration of cached parameters
         """
         # In metalbox mode, collect all dnsmasq entries to write to metalbox device
         if self.config.reconciler_mode == "metalbox" and all_devices:
@@ -41,9 +43,13 @@ class DnsmasqManager:
             for device in all_devices:
                 logger.debug(f"Collecting OOB interface for device {device}")
 
-                # Check if dnsmasq_parameters custom field exists and use it
+                # Check if dnsmasq_parameters custom field exists and use it (unless cache flush is requested)
                 cached_params = device.custom_fields.get("dnsmasq_parameters")
-                if cached_params and isinstance(cached_params, dict):
+                if (
+                    cached_params
+                    and isinstance(cached_params, dict)
+                    and not flush_cache
+                ):
                     logger.info(
                         f"Using cached dnsmasq parameters for device {device.name}"
                     )
@@ -138,9 +144,9 @@ class DnsmasqManager:
         for device in devices:
             logger.debug(f"Checking OOB interface for device {device}")
 
-            # Check if dnsmasq_parameters custom field exists and use it
+            # Check if dnsmasq_parameters custom field exists and use it (unless cache flush is requested)
             cached_params = device.custom_fields.get("dnsmasq_parameters")
-            if cached_params and isinstance(cached_params, dict):
+            if cached_params and isinstance(cached_params, dict) and not flush_cache:
                 logger.info(f"Using cached dnsmasq parameters for device {device.name}")
                 # Extract the cached values
                 if (

--- a/files/netbox/extractors/frr_extractor.py
+++ b/files/netbox/extractors/frr_extractor.py
@@ -300,13 +300,17 @@ class FRRExtractor(BaseExtractor):
         Returns:
             FRR parameters dictionary or None if no config found
         """
-        # Check if manual frr_parameters is set
-        custom_field_extractor = CustomFieldExtractor()
-        manual_params = custom_field_extractor.extract(
-            device, field_name="frr_parameters"
-        )
-        if manual_params:
-            return manual_params
+        # Check flush_cache flag
+        flush_cache = kwargs.get("flush_cache", False)
+
+        # Check if manual frr_parameters is set (unless cache flush is requested)
+        if not flush_cache:
+            custom_field_extractor = CustomFieldExtractor()
+            manual_params = custom_field_extractor.extract(
+                device, field_name="frr_parameters"
+            )
+            if manual_params:
+                return manual_params
 
         if not self.api:
             return None

--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -47,13 +47,17 @@ class NetplanExtractor(BaseExtractor):
         Returns:
             Netplan parameters dictionary or None if no config found
         """
-        # Check if manual netplan_parameters is set
-        custom_field_extractor = CustomFieldExtractor()
-        manual_params = custom_field_extractor.extract(
-            device, field_name="netplan_parameters"
-        )
-        if manual_params:
-            return manual_params
+        # Check flush_cache flag
+        flush_cache = kwargs.get("flush_cache", False)
+
+        # Check if manual netplan_parameters is set (unless cache flush is requested)
+        if not flush_cache:
+            custom_field_extractor = CustomFieldExtractor()
+            manual_params = custom_field_extractor.extract(
+                device, field_name="netplan_parameters"
+            )
+            if manual_params:
+                return manual_params
 
         # Get interfaces from device using API filter
         if not self.api:

--- a/files/netbox/inventory_manager.py
+++ b/files/netbox/inventory_manager.py
@@ -43,6 +43,7 @@ class InventoryManager:
             self.config.default_mtu,
             self.config.default_local_as_prefix,
             self.config.frr_switch_roles,
+            self.config.flush_cache,
         )
 
         # Store in cache for later use

--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -98,10 +98,12 @@ def main() -> None:
         # In metalbox mode, pass all_devices to collect OOB configs from all devices
         if config.reconciler_mode == "metalbox":
             dnsmasq_manager.write_dnsmasq_config(
-                netbox_client, inventory_devices, all_devices
+                netbox_client, inventory_devices, all_devices, config.flush_cache
             )
         else:
-            dnsmasq_manager.write_dnsmasq_config(netbox_client, inventory_devices)
+            dnsmasq_manager.write_dnsmasq_config(
+                netbox_client, inventory_devices, flush_cache=config.flush_cache
+            )
 
         # Generate dnsmasq DHCP ranges
         logger.info("Generating dnsmasq DHCP ranges")


### PR DESCRIPTION
… cached parameters

Add support for FLUSH_CACHE environment variable that forces regeneration of cached custom field values (netplan_parameters, frr_parameters, dnsmasq_parameters) when set to true. This is useful when network topology or interface configurations have changed and cached values need to be updated.

AI-assisted: Claude Code