### PR TITLE
netbox: add netplan parameters for leaf interfaces without IP addresses

### DIFF
--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -43,11 +43,18 @@ class DeviceDataExtractor:
         return self.primary_ip_extractor.extract(device)
 
     def extract_netplan_parameters(
-        self, device: Any, default_mtu: int = 9100, flush_cache: bool = False
+        self,
+        device: Any,
+        default_mtu: int = 9100,
+        switch_roles: List[str] = None,
+        flush_cache: bool = False,
     ) -> Any:
         """Extract netplan parameters, combining manual and auto-generated config."""
         return self.netplan_extractor.extract(
-            device, default_mtu=default_mtu, flush_cache=flush_cache
+            device,
+            default_mtu=default_mtu,
+            switch_roles=switch_roles,
+            flush_cache=flush_cache,
         )
 
     def extract_frr_parameters(
@@ -84,7 +91,7 @@ class DeviceDataExtractor:
             "config_context": self.extract_config_context(device),
             "primary_ip": self.extract_primary_ip(device),
             "netplan_parameters": self.extract_netplan_parameters(
-                device, default_mtu, flush_cache
+                device, default_mtu, switch_roles, flush_cache
             ),
             "frr_parameters": self.extract_frr_parameters(
                 device, local_as_prefix, switch_roles, flush_cache


### PR DESCRIPTION
Add link-local IPv6 and disable DHCP for interfaces that are:
- Connected to switches (leaf, accessleaf, dataleaf, etc.)
- Have no IPv4 or IPv6 addresses assigned

This ensures proper IPv6 link-local addressing on leaf connections while preventing DHCP on interfaces meant for BGP unnumbered setups.

AI-assisted: Claude Code