### PR TITLE
netbox: add metalbox dummy interface for metalbox role devices in met…

### DIFF
--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -48,6 +48,7 @@ class DeviceDataExtractor:
         default_mtu: int = 9100,
         switch_roles: List[str] = None,
         flush_cache: bool = False,
+        reconciler_mode: str = "manager",
     ) -> Any:
         """Extract netplan parameters, combining manual and auto-generated config."""
         return self.netplan_extractor.extract(
@@ -55,6 +56,7 @@ class DeviceDataExtractor:
             default_mtu=default_mtu,
             switch_roles=switch_roles,
             flush_cache=flush_cache,
+            reconciler_mode=reconciler_mode,
         )
 
     def extract_frr_parameters(
@@ -85,13 +87,14 @@ class DeviceDataExtractor:
         local_as_prefix: int = 42,
         switch_roles: List[str] = None,
         flush_cache: bool = False,
+        reconciler_mode: str = "manager",
     ) -> Dict[str, Any]:
         """Extract all configured data types from a device."""
         return {
             "config_context": self.extract_config_context(device),
             "primary_ip": self.extract_primary_ip(device),
             "netplan_parameters": self.extract_netplan_parameters(
-                device, default_mtu, switch_roles, flush_cache
+                device, default_mtu, switch_roles, flush_cache, reconciler_mode
             ),
             "frr_parameters": self.extract_frr_parameters(
                 device, local_as_prefix, switch_roles, flush_cache

--- a/files/netbox/inventory_manager.py
+++ b/files/netbox/inventory_manager.py
@@ -44,6 +44,7 @@ class InventoryManager:
             self.config.default_local_as_prefix,
             self.config.frr_switch_roles,
             self.config.flush_cache,
+            self.config.reconciler_mode,
         )
 
         # Store in cache for later use
@@ -78,6 +79,8 @@ class InventoryManager:
                 self.config.default_mtu,
                 self.config.default_local_as_prefix,
                 self.config.frr_switch_roles,
+                self.config.flush_cache,
+                self.config.reconciler_mode,
             )
 
         # Determine base path for device files


### PR DESCRIPTION
…albox mode

When INVENTORY_RECONCILER_MODE is set to "metalbox", devices with the "metalbox" role will now get an additional dummy network interface named "metalbox" with the IP address 192.168.42.10/24 in their netplan parameters.