### PR TITLE
netbox: skip provision state check for ironic devices in metalbox mode

### DIFF
--- a/files/netbox/netbox_client.py
+++ b/files/netbox/netbox_client.py
@@ -86,8 +86,9 @@ class NetBoxClient:
             else:
                 ironic_filter["tag"] = ["managed-by-ironic"]
 
-            # Add provision state filter for ironic devices
-            ironic_filter["cf_provision_state"] = ["active"]
+            # Add provision state filter for ironic devices only if NOT in metalbox mode
+            if self.config.reconciler_mode != "metalbox":
+                ironic_filter["cf_provision_state"] = ["active"]
 
             devices_with_ironic = self.api.dcim.devices.filter(**ironic_filter)
 


### PR DESCRIPTION
In metalbox mode, devices with the "managed-by-ironic" tag are now included regardless of their provision_state. This allows metalbox deployments to manage all ironic devices without requiring them to be in "active" state.

AI-assisted: Claude Code