### PR TITLE
netbox: inherit MTU from parent interface for VLAN interfaces

### DIFF
--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -163,6 +163,15 @@ class NetplanExtractor(BaseExtractor):
                                 ),
                             }
 
+                            # Use parent interface's MTU if available, otherwise use default
+                            if (
+                                hasattr(interface.parent, "mtu")
+                                and interface.parent.mtu
+                            ):
+                                vlan_config["mtu"] = interface.parent.mtu
+                            else:
+                                vlan_config["mtu"] = default_mtu
+
                             # Get IP addresses for this VLAN interface
                             addresses = []
                             try:


### PR DESCRIPTION
VLAN interfaces now use the MTU value from their parent interface instead of always using the default. Falls back to default MTU if parent has no MTU configured. This prevents MTU mismatches between VLAN and parent interfaces.

AI-assisted: Claude Code