### PR TITLE
netbox: fix duplicate vlan prefix in metalbox dynamic host entries

### DIFF
--- a/files/netbox/dnsmasq/metalbox_mode.py
+++ b/files/netbox/dnsmasq/metalbox_mode.py
@@ -102,7 +102,7 @@ class MetalboxModeHandler(DnsmasqBase):
                             # Check if this IP belongs to the network
                             if ip_addr in network_obj:
                                 # Create dynamic host entry using interface label/name
-                                entry = f"metalbox,{ip_only},vlan{interface_info['interface_identifier']}"
+                                entry = f"metalbox,{ip_only},{interface_info['interface_identifier']}"
                                 dynamic_hosts.append(entry)
                                 logger.debug(f"Created dynamic host entry: {entry}")
                                 break  # Only use the first matching IP


### PR DESCRIPTION
Remove redundant "vlan" prefix when creating dynamic host entries. The interface identifier already contains "vlan" in its name (e.g., "vlan123"), so adding another "vlan" prefix resulted in entries like "vlanvlan123"

AI-assisted: Claude Code