### PR TITLE
netbox: improve file cache behavior to always read existing cache

### DIFF
--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -34,11 +34,11 @@ def main() -> None:
             f"Generate the inventory from the Netbox ({config.reconciler_mode} mode)"
         )
 
-        # Initialize file cache if enabled
-        file_cache = None
-        if config.write_cache:
-            file_cache = FileCache()
-            file_cache.load(flush_cache=config.flush_cache)
+        # Initialize file cache (always initialize to allow reading from existing cache)
+        file_cache = FileCache()
+        # Load cache from file if it exists, unless FLUSH_CACHE is true
+        if not config.flush_cache:
+            file_cache.load(flush_cache=False)
 
         # Initialize components
         netbox_client = NetBoxClient(config, file_cache=file_cache)


### PR DESCRIPTION
- Always initialize FileCache to allow reading from existing cache file
- Load cache from /tmp/netbox_cache.json if it exists (regardless of WRITE_CACHE setting)
- Only write cache file when WRITE_CACHE=true
- Skip loading cache when FLUSH_CACHE=true to force regeneration

This change allows the cache to be used even when WRITE_CACHE=false, reducing NetBox API calls when a cache file exists from a previous run.

AI-assisted: Claude Code