### PR TITLE
netbox: filter dnsmasq interfaces based on DHCP entry presence

### DIFF
--- a/files/netbox/dnsmasq/interface_handler.py
+++ b/files/netbox/dnsmasq/interface_handler.py
@@ -14,7 +14,11 @@ class InterfaceHandler:
 
     @staticmethod
     def get_virtual_interfaces_for_dnsmasq(
-        device: Any, netbox_client: NetBoxClient
+        device: Any,
+        netbox_client: NetBoxClient,
+        dhcp_hosts: List[str] = None,
+        dhcp_options: List[str] = None,
+        dynamic_hosts: List[str] = None,
     ) -> List[str]:
         """Get virtual interfaces with untagged VLANs for dnsmasq configuration.
 
@@ -22,10 +26,14 @@ class InterfaceHandler:
         - The "managed-by-osism" tag
         - An untagged VLAN
         - Type = virtual
+        - AND have corresponding DHCP entries for their VLAN
 
         Args:
             device: NetBox device object
             netbox_client: NetBox API client
+            dhcp_hosts: List of DHCP host entries to check for VLAN tags
+            dhcp_options: List of DHCP option entries to check for VLAN tags
+            dynamic_hosts: List of dynamic host entries to check for interface names
 
         Returns:
             List of interface names for dnsmasq configuration
@@ -61,10 +69,45 @@ class InterfaceHandler:
 
             # Use label if set, otherwise use name
             interface_name = interface.label if interface.label else interface.name
-            if interface_name:
+            if not interface_name:
+                continue
+
+            vlan_id = interface.untagged_vlan.vid
+            vlan_tag = f"vlan{vlan_id}"
+
+            # Check if there are any DHCP entries for this VLAN
+            has_dhcp_entries = False
+
+            # Check dhcp_hosts for set:vlanXXX tags
+            if dhcp_hosts:
+                for entry in dhcp_hosts:
+                    if f"set:{vlan_tag}" in entry:
+                        has_dhcp_entries = True
+                        break
+
+            # Check dhcp_options for tag:vlanXXX
+            if not has_dhcp_entries and dhcp_options:
+                for entry in dhcp_options:
+                    if f"tag:{vlan_tag}" in entry:
+                        has_dhcp_entries = True
+                        break
+
+            # Check dynamic_hosts for interface name
+            if not has_dhcp_entries and dynamic_hosts:
+                for entry in dynamic_hosts:
+                    if interface_name in entry:
+                        has_dhcp_entries = True
+                        break
+
+            # Only add interface if there are DHCP entries for its VLAN
+            if has_dhcp_entries:
                 dnsmasq_interfaces.append(interface_name)
                 logger.debug(
-                    f"Found virtual interface {interface_name} with VLAN {interface.untagged_vlan.vid} for dnsmasq"
+                    f"Found virtual interface {interface_name} with VLAN {vlan_id} for dnsmasq (has DHCP entries)"
+                )
+            else:
+                logger.debug(
+                    f"Skipping virtual interface {interface_name} with VLAN {vlan_id} - no DHCP entries found"
                 )
 
         return dnsmasq_interfaces

--- a/files/netbox/dnsmasq/metalbox_mode.py
+++ b/files/netbox/dnsmasq/metalbox_mode.py
@@ -268,15 +268,8 @@ class MetalboxModeHandler(DnsmasqBase):
                 all_dhcp_hosts.append(host_entry)
                 logger.debug(f"Collected dnsmasq entry for {device.name}: {host_entry}")
 
-                # Get virtual interfaces for this device (only for metalbox devices)
+                # Note: We'll collect interfaces later after we have all DHCP entries
                 device_interfaces = []
-                if is_metalbox:
-                    device_interfaces = (
-                        self.interface_handler.get_virtual_interfaces_for_dnsmasq(
-                            device, netbox_client
-                        )
-                    )
-                    all_dnsmasq_interfaces.extend(device_interfaces)
 
                 # Prepare parameters for caching
                 cache_params = {
@@ -308,27 +301,10 @@ class MetalboxModeHandler(DnsmasqBase):
                         f"Failed to cache dnsmasq parameters for device {device.name}"
                     )
             else:
-                # No OOB interface found, but still check for virtual interfaces (only for metalbox devices)
-                if is_metalbox:
-                    device_interfaces = (
-                        self.interface_handler.get_virtual_interfaces_for_dnsmasq(
-                            device, netbox_client
-                        )
-                    )
-                    if device_interfaces:
-                        all_dnsmasq_interfaces.extend(device_interfaces)
-                        # Cache just the interfaces
-                        cache_params = {
-                            "dnsmasq_dhcp_hosts": [],
-                            "dnsmasq_dhcp_macs": [],
-                            "dnsmasq_interfaces": device_interfaces,
-                        }
-                        logger.info(
-                            f"Caching dnsmasq interfaces for metalbox device {device.name}"
-                        )
-                        netbox_client.update_device_custom_field(
-                            device, "dnsmasq_parameters", cache_params
-                        )
+                # No OOB interface found
+                logger.debug(
+                    f"No OOB interface found for device {device.name} - interfaces will be collected later"
+                )
 
         # Write collected entries to metalbox device(s)
         for device in devices:
@@ -345,11 +321,26 @@ class MetalboxModeHandler(DnsmasqBase):
                 # Generate DHCP options for this metalbox device
                 dhcp_options = self.get_dhcp_options_for_metalbox(device, netbox_client)
 
-                # Create the dnsmasq configuration data with all collected entries
+                # Now filter interfaces based on DHCP entries
+                filtered_interfaces = []
+                if all_dnsmasq_interfaces:
+                    # Get interfaces again with filtering based on collected DHCP entries
+                    device_interfaces = (
+                        self.interface_handler.get_virtual_interfaces_for_dnsmasq(
+                            device,
+                            netbox_client,
+                            dhcp_hosts=all_dhcp_hosts,
+                            dhcp_options=dhcp_options,
+                            dynamic_hosts=dynamic_hosts,
+                        )
+                    )
+                    filtered_interfaces.extend(device_interfaces)
+
+                # Create the dnsmasq configuration data with filtered interfaces
                 dnsmasq_data = {
                     "dnsmasq_dhcp_hosts": all_dhcp_hosts,
                     "dnsmasq_dhcp_macs": all_dhcp_macs,
-                    "dnsmasq_interfaces": all_dnsmasq_interfaces,
+                    "dnsmasq_interfaces": filtered_interfaces,
                     "dnsmasq_dynamic_hosts": dynamic_hosts,
                     "dnsmasq_dhcp_options": dhcp_options,
                 }
@@ -357,5 +348,9 @@ class MetalboxModeHandler(DnsmasqBase):
                 # Write to metalbox device's host vars
                 self.write_dnsmasq_to_device(device, dnsmasq_data)
                 logger.info(
-                    f"Wrote {len(all_dhcp_hosts)} dnsmasq entries, {len(dynamic_hosts)} dynamic hosts and {len(dhcp_options)} DHCP options to metalbox device {device.name}"
+                    f"Wrote {len(all_dhcp_hosts)} dnsmasq entries, "
+                    f"{len(dynamic_hosts)} dynamic hosts, "
+                    f"{len(dhcp_options)} DHCP options, "
+                    f"and {len(filtered_interfaces)} interfaces "
+                    f"to metalbox device {device.name}"
                 )


### PR DESCRIPTION
Only include interfaces in dnsmasq_interfaces when there are actual DHCP entries (hosts, options, or dynamic hosts) for the interface's VLAN. This prevents unnecessary interface declarations in dnsmasq configuration.

- Modified interface_handler to accept and check DHCP entries
- Updated metalbox_mode to collect all DHCP entries first, then filter interfaces
- Interfaces are now only included if their VLAN has associated DHCP configurations

AI-assisted: Claude Code