### PR TITLE
Use correct dnsmasq dhcp-mac syntax from tag: to set: for device type…

### DIFF
--- a/files/netbox/dnsmasq/dhcp_config.py
+++ b/files/netbox/dnsmasq/dhcp_config.py
@@ -66,8 +66,8 @@ class DHCPConfigGenerator:
         elif device.device_type and device.device_type.slug:
             # Fallback to device type slug
             device_type_slug = device.device_type.slug
-            # Format: dhcp-mac=tag:device-type-slug,mac-address
-            return f"tag:{device_type_slug},{mac_formatted}"
+            # Format: dhcp-mac=set:device-type-slug,mac-address
+            return f"set:{device_type_slug},{mac_formatted}"
 
         return None
 


### PR DESCRIPTION
… slugs

When generating DHCP configurations from NetBox device types, use the correct dnsmasq syntax "set:" instead of "tag:" in dhcp-mac directives. This ensures proper tag assignment for MAC addresses based on device type slugs.