### PR TITLE
netbox; add metalbox mode for FRR and Netplan parameter caching

### DIFF
--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -61,9 +61,17 @@ def main() -> None:
         for device in all_devices:
             logger.info(f"Extracting data for {device.name}")
             if config.data_types:
-                inventory_manager.extract_device_data(
-                    device, data_types=config.data_types
-                )
+                # In metalbox mode, ensure FRR and Netplan parameters are always extracted
+                # to generate and cache them in NetBox
+                if config.reconciler_mode == "metalbox":
+                    data_types = list(
+                        set(
+                            config.data_types + ["frr_parameters", "netplan_parameters"]
+                        )
+                    )
+                else:
+                    data_types = config.data_types
+                inventory_manager.extract_device_data(device, data_types=data_types)
             else:
                 inventory_manager.extract_device_config_context(device)
 
@@ -93,9 +101,16 @@ def main() -> None:
         for device in inventory_devices:
             logger.info(f"Writing files for {get_inventory_hostname(device)}")
             if config.data_types:
-                inventory_manager.write_device_data(
-                    device, data_types=config.data_types
-                )
+                # In metalbox mode, exclude FRR and Netplan parameters from being written to files
+                if config.reconciler_mode == "metalbox":
+                    data_types = [
+                        dt
+                        for dt in config.data_types
+                        if dt not in ["frr_parameters", "netplan_parameters"]
+                    ]
+                else:
+                    data_types = config.data_types
+                inventory_manager.write_device_data(device, data_types=data_types)
             else:
                 inventory_manager.write_device_config_context(device)
 


### PR DESCRIPTION
In metalbox mode, ensure FRR and Netplan parameters are always extracted and cached in NetBox custom fields, but exclude them from being written to inventory files. This allows metalbox environments to generate and cache these parameters for API access without polluting inventory files.

AI-assisted: Claude Code