### PR TITLE
netbox: add INVENTORY_FROM_NETBOX environment variable to control fil…

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -44,6 +44,7 @@ This NetBox module is part of the OSISM Container Image Inventory Reconciler. It
 - `INVENTORY_RECONCILER_MODE` - Operating mode for the reconciler: "manager" or "metalbox" (default: "manager")
 - `FLUSH_CACHE` - Force regeneration of cached custom field values (default: false)
 - `WRITE_CACHE` - Write cache to local file for persistence across runs (default: false)
+- `INVENTORY_FROM_NETBOX` - Whether to write inventory files to DEFAULT_INVENTORY_PATH (default: true)
 
 ## Device Selection Logic
 

--- a/files/netbox/config.py
+++ b/files/netbox/config.py
@@ -57,6 +57,7 @@ class Config:
         reconciler_mode: Operating mode for the reconciler (manager or metalbox)
         flush_cache: Force regeneration of cached custom field values
         write_cache: Write cache to local file for persistence across runs
+        inventory_from_netbox: Whether to write inventory files to DEFAULT_INVENTORY_PATH
     """
 
     netbox_url: str
@@ -81,6 +82,7 @@ class Config:
     reconciler_mode: str = DEFAULT_RECONCILER_MODE
     flush_cache: bool = False
     write_cache: bool = False
+    inventory_from_netbox: bool = True
 
     @classmethod
     def from_environment(cls) -> "Config":
@@ -140,6 +142,7 @@ class Config:
             reconciler_mode=reconciler_mode,
             flush_cache=SETTINGS.get("FLUSH_CACHE", False),
             write_cache=SETTINGS.get("WRITE_CACHE", False),
+            inventory_from_netbox=SETTINGS.get("INVENTORY_FROM_NETBOX", True),
         )
 
     @staticmethod


### PR DESCRIPTION
…e writing

Add new INVENTORY_FROM_NETBOX boolean environment variable (default: true) that controls whether inventory files are written to DEFAULT_INVENTORY_PATH. When set to false, all inventory file writing operations are skipped while maintaining NetBox data extraction and caching functionality.

Changes:
- Add inventory_from_netbox configuration option to Config class
- Wrap all inventory file writing operations in conditional check
- Update documentation with new environment variable
- Preserve data extraction and caching regardless of setting

AI-assisted: Claude Code