### PR TITLE
Remove INVENTORY_FROM_NETBOX check from run.sh script

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -56,7 +56,7 @@ if [[ -e /interface/overlays/release-kolla-ansible.yml ]]; then
     cp /interface/overlays/release-kolla-ansible.yml /inventory.pre/group_vars/all/100-overlays-release-kolla-ansible.yml
 fi
 
-if [[ -e /run/secrets/NETBOX_TOKEN && ! -z "$(cat /run/secrets/NETBOX_TOKEN)" && $INVENTORY_FROM_NETBOX == "True" ]]; then
+if [[ -e /run/secrets/NETBOX_TOKEN && ! -z "$(cat /run/secrets/NETBOX_TOKEN)" ]]; then
     python3 /netbox/main.py
 fi
 


### PR DESCRIPTION
The INVENTORY_FROM_NETBOX environment variable check is now handled internally within the NetBox Python module itself, so the shell script condition is no longer needed. The NetBox module will run but skip file writing operations when INVENTORY_FROM_NETBOX is set to false.