### PR TITLE
netbox: set default DHCP tag to 'ironic' for managed-by-ironic devices

### DIFF
--- a/files/netbox/dnsmasq/dhcp_config.py
+++ b/files/netbox/dnsmasq/dhcp_config.py
@@ -63,6 +63,9 @@ class DHCPConfigGenerator:
         if custom_dhcp_tag:
             # Use custom field value if set
             return f"set:{custom_dhcp_tag},{mac_formatted}"
+        elif any(tag.name == "managed-by-ironic" for tag in device.tags):
+            # Set default tag to 'ironic' for devices with managed-by-ironic tag
+            return f"set:ironic,{mac_formatted}"
         elif device.device_type and device.device_type.slug:
             # Fallback to device type slug
             device_type_slug = device.device_type.slug


### PR DESCRIPTION
Previously devices with the 'managed-by-ironic' tag would use the device type slug as the DHCP tag. This change sets the default DHCP tag to 'ironic' for these devices to provide consistent tagging for Ironic managed nodes.

AI-assisted: Claude Code