### PR TITLE
netbox: Add GNMI host vars support for metalbox-managed switches

### DIFF
--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -8,6 +8,7 @@ from extractors import (
     ConfigContextExtractor,
     CustomFieldExtractor,
     FRRExtractor,
+    GNMIExtractor,
     NetplanExtractor,
     PrimaryIPExtractor,
 )
@@ -33,6 +34,7 @@ class DeviceDataExtractor:
         self.frr_extractor = FRRExtractor(
             api=api, netbox_client=netbox_client, file_cache=file_cache
         )
+        self.gnmi_extractor = GNMIExtractor()
         self.netbox_client = netbox_client
         self.file_cache = file_cache
 
@@ -86,6 +88,10 @@ class DeviceDataExtractor:
             device, field_name="dnsmasq_parameters"
         )
 
+    def extract_gnmi_parameters(self, device: Any) -> Any:
+        """Extract GNMI parameters for metalbox-managed switches."""
+        return self.gnmi_extractor.extract(device)
+
     def extract_all_data(
         self,
         device: Any,
@@ -106,4 +112,5 @@ class DeviceDataExtractor:
                 device, local_as_prefix, switch_roles, flush_cache
             ),
             "dnsmasq_parameters": self.extract_dnsmasq_parameters(device),
+            "gnmi_parameters": self.extract_gnmi_parameters(device),
         }

--- a/files/netbox/extractors/__init__.py
+++ b/files/netbox/extractors/__init__.py
@@ -6,6 +6,7 @@ from .base_extractor import BaseExtractor
 from .config_context_extractor import ConfigContextExtractor
 from .custom_field_extractor import CustomFieldExtractor
 from .frr_extractor import FRRExtractor
+from .gnmi_extractor import GNMIExtractor
 from .netplan_extractor import NetplanExtractor
 from .primary_ip_extractor import PrimaryIPExtractor
 
@@ -14,6 +15,7 @@ __all__ = [
     "ConfigContextExtractor",
     "CustomFieldExtractor",
     "FRRExtractor",
+    "GNMIExtractor",
     "NetplanExtractor",
     "PrimaryIPExtractor",
 ]

--- a/files/netbox/extractors/gnmi_extractor.py
+++ b/files/netbox/extractors/gnmi_extractor.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""GNMI parameters extractor for metalbox switches."""
+
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+from .base_extractor import BaseExtractor
+
+
+class GNMIExtractor(BaseExtractor):
+    """Extracts GNMI parameters for switches managed by metalbox."""
+
+    def extract(self, device: Any, **kwargs) -> Optional[Dict[str, Any]]:
+        """Extract GNMI parameters for metalbox-managed switches.
+
+        Args:
+            device: NetBox device object
+            **kwargs: Additional parameters (unused)
+
+        Returns:
+            Dictionary containing GNMI configuration for the switch, or None if not applicable
+        """
+        # Check if device has managed-by-metalbox tag
+        if not self._has_metalbox_tag(device):
+            logger.debug(f"Device {device.name} does not have managed-by-metalbox tag")
+            return None
+
+        # Get hostname (from custom field or device name)
+        hostname = self._get_hostname(device)
+
+        # Get OOB IP address
+        oob_ip = self._get_oob_ip(device)
+        if not oob_ip:
+            logger.warning(f"No OOB IP address found for device {device.name}")
+            return None
+
+        # Generate GNMI configuration
+        gnmi_config = {
+            f"gnmic_targets__{hostname}": {
+                f"{oob_ip}:8080": {
+                    "username": "admin",
+                    "password": "YourPaSsWoRd",
+                    "encoding": "json",
+                    "subscriptions": ["all-interfaces"],
+                }
+            }
+        }
+
+        logger.debug(f"Generated GNMI config for {device.name}: {gnmi_config}")
+        return gnmi_config
+
+    def _has_metalbox_tag(self, device: Any) -> bool:
+        """Check if device has managed-by-metalbox tag.
+
+        Args:
+            device: NetBox device object
+
+        Returns:
+            True if device has managed-by-metalbox tag, False otherwise
+        """
+        if not hasattr(device, "tags") or not device.tags:
+            return False
+
+        tag_slugs = [tag.slug for tag in device.tags]
+        return "managed-by-metalbox" in tag_slugs
+
+    def _get_hostname(self, device: Any) -> str:
+        """Get hostname from custom field or device name.
+
+        Args:
+            device: NetBox device object
+
+        Returns:
+            Hostname string (inventory_hostname custom field or device name)
+        """
+        # Check for inventory_hostname custom field first
+        if (
+            hasattr(device, "custom_fields")
+            and device.custom_fields
+            and device.custom_fields.get("inventory_hostname")
+        ):
+            return device.custom_fields["inventory_hostname"]
+
+        # Fall back to device name
+        return device.name
+
+    def _get_oob_ip(self, device: Any) -> Optional[str]:
+        """Get OOB IP address for the device.
+
+        Args:
+            device: NetBox device object
+
+        Returns:
+            OOB IP address string (without subnet mask), or None if not found
+        """
+        # Look for OOB interface by checking all interfaces
+        if not hasattr(device, "interfaces"):
+            return None
+
+        try:
+            interfaces = device.interfaces.all()
+            for interface in interfaces:
+                # Check if this is an OOB interface (common naming patterns)
+                if (
+                    hasattr(interface, "name")
+                    and interface.name
+                    and (
+                        "oob" in interface.name.lower()
+                        or "mgmt" in interface.name.lower()
+                        or "management" in interface.name.lower()
+                    )
+                ):
+
+                    # Get IP addresses assigned to this interface
+                    if hasattr(interface, "ip_addresses"):
+                        ip_addresses = interface.ip_addresses.all()
+                        for ip in ip_addresses:
+                            if hasattr(ip, "address") and ip.address:
+                                # Return the first IP address found (without subnet mask)
+                                return ip.address.split("/")[0]
+        except Exception as e:
+            logger.warning(f"Error getting OOB IP for device {device.name}: {e}")
+
+        # Fallback to primary IP if no OOB interface found
+        if hasattr(device, "primary_ip4") and device.primary_ip4:
+            return device.primary_ip4.address.split("/")[0]
+        elif hasattr(device, "primary_ip6") and device.primary_ip6:
+            return device.primary_ip6.address.split("/")[0]
+        elif hasattr(device, "primary_ip") and device.primary_ip:
+            return device.primary_ip.address.split("/")[0]
+
+        return None

--- a/files/netbox/inventory/file_writer.py
+++ b/files/netbox/inventory/file_writer.py
@@ -22,6 +22,7 @@ class FileWriter(BaseInventoryComponent):
         "netplan_parameters": "999-netbox-netplan.yml",
         "frr_parameters": "999-netbox-frr.yml",
         "dnsmasq_parameters": "999-netbox-dnsmasq.yml",
+        "gnmi_parameters": "999-netbox-gnmi.yml",
     }
 
     def write_device_data(self, device: Any, data_type: str, data: Any) -> None:
@@ -83,6 +84,7 @@ class FileWriter(BaseInventoryComponent):
             "frr_parameters",
             "netplan_parameters",
             "dnsmasq_parameters",
+            "gnmi_parameters",
         ]:
             # Write these parameters directly without wrapper
             return yaml.dump(data, Dumper=yaml.Dumper)


### PR DESCRIPTION
Add new GNMI data extractor that generates host vars for switches tagged with 'managed-by-metalbox'. Creates 999-netbox-gnmi.yml files with gnmic_targets configuration using OOB IP addresses and device hostnames (from inventory_hostname custom field or device name).

AI-assisted: Claude Code