### PR TITLE
netbox: standardize GNMI extractor initialization

### DIFF
--- a/files/merge-inventory-files.py
+++ b/files/merge-inventory-files.py
@@ -47,9 +47,7 @@ def read_config_file(filepath: Path) -> Optional[configparser.ConfigParser]:
         Configured ConfigParser object or None if error occurs
     """
     try:
-        config = configparser.ConfigParser(
-            allow_no_value=True
-        )
+        config = configparser.ConfigParser(allow_no_value=True)
         config.read(filepath)
         return config
     except (UnicodeDecodeError, configparser.Error) as e:
@@ -72,7 +70,7 @@ def write_config_file(config: configparser.ConfigParser, filepath: Path) -> bool
     output = StringIO()
     config.write(output)
     content = output.getvalue()
-    content = re.sub(r'^(\w+)\s*=\s*$', r'\1', content, flags=re.MULTILINE)
+    content = re.sub(r"^(\w+)\s*=\s*$", r"\1", content, flags=re.MULTILINE)
 
     try:
         with open(filepath, "w") as fp:

--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -21,7 +21,7 @@ class DeviceDataExtractor:
         """Initialize extractors.
 
         Args:
-            api: NetBox API instance (required for NetplanExtractor and FRRExtractor)
+            api: NetBox API instance (required for NetplanExtractor, FRRExtractor, and GNMIExtractor)
             netbox_client: NetBox client instance for updating custom fields
             file_cache: FileCache instance for persistent caching
         """
@@ -34,7 +34,9 @@ class DeviceDataExtractor:
         self.frr_extractor = FRRExtractor(
             api=api, netbox_client=netbox_client, file_cache=file_cache
         )
-        self.gnmi_extractor = GNMIExtractor()
+        self.gnmi_extractor = GNMIExtractor(
+            api=api, netbox_client=netbox_client, file_cache=file_cache
+        )
         self.netbox_client = netbox_client
         self.file_cache = file_cache
 


### PR DESCRIPTION
Update GNMIExtractor to use consistent initialization pattern with other extractors by accepting api, netbox_client, and file_cache parameters in constructor. This ensures proper API access through self.api instead of kwargs.

AI-assisted: Claude Code