### PR TITLE
Add INVENTORY_IGNORE_PROVISION_STATE configuration option

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -45,13 +45,14 @@ This NetBox module is part of the OSISM Container Image Inventory Reconciler. It
 - `FLUSH_CACHE` - Force regeneration of cached custom field values (default: false)
 - `WRITE_CACHE` - Write cache to local file for persistence across runs (default: false)
 - `INVENTORY_FROM_NETBOX` - Whether to write inventory files to DEFAULT_INVENTORY_PATH (default: true)
+- `INVENTORY_IGNORE_PROVISION_STATE` - Ignore cf_provision_state filter for Ironic devices (default: false)
 
 ## Device Selection Logic
 
 ### Devices are selected if:
 - They match the filter criteria specified in `NETBOX_FILTER_INVENTORY` (default: status="active" AND tag="managed-by-osism")
 - NOT in maintenance mode (custom field)
-- For devices also tagged with "managed-by-ironic": provision_state must be "active"
+- For devices also tagged with "managed-by-ironic": provision_state must be "active" (unless INVENTORY_IGNORE_PROVISION_STATE is true)
 
 ### Custom Filter Examples
 - Single filter (dictionary): `{"status": "active", "tag": "managed-by-osism", "device_type": "server"}`

--- a/files/netbox/config.py
+++ b/files/netbox/config.py
@@ -59,6 +59,7 @@ class Config:
         flush_cache: Force regeneration of cached custom field values
         write_cache: Write cache to local file for persistence across runs
         inventory_from_netbox: Whether to write inventory files to DEFAULT_INVENTORY_PATH
+        ignore_provision_state: Ignore cf_provision_state filter for Ironic devices
     """
 
     netbox_url: str
@@ -84,6 +85,7 @@ class Config:
     flush_cache: bool = False
     write_cache: bool = False
     inventory_from_netbox: bool = True
+    ignore_provision_state: bool = False
 
     @classmethod
     def from_environment(cls) -> "Config":
@@ -150,6 +152,9 @@ class Config:
             flush_cache=SETTINGS.get("FLUSH_CACHE", False),
             write_cache=SETTINGS.get("WRITE_CACHE", False),
             inventory_from_netbox=SETTINGS.get("INVENTORY_FROM_NETBOX", True),
+            ignore_provision_state=SETTINGS.get(
+                "INVENTORY_IGNORE_PROVISION_STATE", False
+            ),
         )
 
     @staticmethod

--- a/files/netbox/filters.py
+++ b/files/netbox/filters.py
@@ -45,8 +45,11 @@ class DeviceFilter:
         else:
             ironic_filter["tag"] = ["managed-by-ironic"]
 
-        # Add provision state filter for ironic devices only if NOT in metalbox mode
-        if self.config.reconciler_mode != "metalbox":
+        # Add provision state filter for ironic devices only if NOT in metalbox mode and NOT ignoring provision state
+        if (
+            self.config.reconciler_mode != "metalbox"
+            and not self.config.ignore_provision_state
+        ):
             ironic_filter["cf_provision_state"] = ["active"]
 
         return ironic_filter


### PR DESCRIPTION
Adds new configuration option to allow ignoring provision state filters for Ironic devices when building inventory from NetBox.

AI-assisted: Claude Code