### PR TITLE
Handle disabled interfaces differently in FRR and Netplan parameter g…

### DIFF
--- a/files/netbox/extractors/frr_extractor.py
+++ b/files/netbox/extractors/frr_extractor.py
@@ -77,6 +77,7 @@ class InterfaceFilter:
         - managed-by-osism tag
         - a label
         - connected endpoints
+        - enabled status
 
         Args:
             interface: NetBox interface object
@@ -89,6 +90,7 @@ class InterfaceFilter:
             and bool(interface.label)
             and hasattr(interface, "connected_endpoints")
             and bool(interface.connected_endpoints)
+            and getattr(interface, "enabled", True)
         )
 
 

--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -226,6 +226,14 @@ class NetplanExtractor(BaseExtractor):
                 "set-name": label,
             }
 
+            # Check if interface is disabled
+            is_enabled = getattr(interface, "enabled", True)
+            if not is_enabled:
+                # For disabled interfaces, only set basic config and mark as down
+                interface_config["activation-mode"] = "off"
+                network_ethernets[label] = interface_config
+                continue
+
             # Add MTU - use interface MTU if set, otherwise use default
             if hasattr(interface, "mtu") and interface.mtu:
                 interface_config["mtu"] = interface.mtu


### PR DESCRIPTION
…eneration

- FRR extractor: Exclude disabled interfaces from parameter generation completely
- Netplan extractor: Include disabled interfaces with minimal configuration
  - Only MAC address matching and interface name
  - Set activation-mode to "off" to explicitly disable the interface
  - Exclude MTU, IP addresses, VLANs and other configurations for disabled interfaces

AI-assisted: Claude Code