### PR TITLE
Add INVENTORY_IGNORE_MAINTENANCE_STATE configuration option

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -46,12 +46,13 @@ This NetBox module is part of the OSISM Container Image Inventory Reconciler. It
 - `WRITE_CACHE` - Write cache to local file for persistence across runs (default: false)
 - `INVENTORY_FROM_NETBOX` - Whether to write inventory files to DEFAULT_INVENTORY_PATH (default: true)
 - `INVENTORY_IGNORE_PROVISION_STATE` - Ignore cf_provision_state filter for Ironic devices (default: false)
+- `INVENTORY_IGNORE_MAINTENANCE_STATE` - Ignore maintenance state filter for devices (default: false)
 
 ## Device Selection Logic
 
 ### Devices are selected if:
 - They match the filter criteria specified in `NETBOX_FILTER_INVENTORY` (default: status="active" AND tag="managed-by-osism")
-- NOT in maintenance mode (custom field)
+- NOT in maintenance mode (custom field) - unless INVENTORY_IGNORE_MAINTENANCE_STATE is true
 - For devices also tagged with "managed-by-ironic": provision_state must be "active" (unless INVENTORY_IGNORE_PROVISION_STATE is true)
 
 ### Custom Filter Examples

--- a/files/netbox/config.py
+++ b/files/netbox/config.py
@@ -60,6 +60,7 @@ class Config:
         write_cache: Write cache to local file for persistence across runs
         inventory_from_netbox: Whether to write inventory files to DEFAULT_INVENTORY_PATH
         ignore_provision_state: Ignore cf_provision_state filter for Ironic devices
+        ignore_maintenance_state: Ignore maintenance state filter for devices
     """
 
     netbox_url: str
@@ -86,6 +87,7 @@ class Config:
     write_cache: bool = False
     inventory_from_netbox: bool = True
     ignore_provision_state: bool = False
+    ignore_maintenance_state: bool = False
 
     @classmethod
     def from_environment(cls) -> "Config":
@@ -154,6 +156,9 @@ class Config:
             inventory_from_netbox=SETTINGS.get("INVENTORY_FROM_NETBOX", True),
             ignore_provision_state=SETTINGS.get(
                 "INVENTORY_IGNORE_PROVISION_STATE", False
+            ),
+            ignore_maintenance_state=SETTINGS.get(
+                "INVENTORY_IGNORE_MAINTENANCE_STATE", False
             ),
         )
 

--- a/files/netbox/filters.py
+++ b/files/netbox/filters.py
@@ -63,6 +63,9 @@ class DeviceFilter:
         Returns:
             List of devices not in maintenance
         """
+        if self.config.ignore_maintenance_state:
+            return devices
+
         return [
             device
             for device in devices
@@ -78,11 +81,19 @@ class DeviceFilter:
         Returns:
             List of devices not managed by Ironic
         """
-        return [
+        filtered_devices = [
             device
             for device in devices
             if "managed-by-ironic" not in [tag.slug for tag in device.tags]
-            and device.custom_fields.get("maintenance") is not True
+        ]
+
+        if self.config.ignore_maintenance_state:
+            return filtered_devices
+
+        return [
+            device
+            for device in filtered_devices
+            if device.custom_fields.get("maintenance") is not True
         ]
 
     def deduplicate_devices(self, devices: List[Any]) -> List[Any]:


### PR DESCRIPTION
Introduce a new configuration option INVENTORY_IGNORE_MAINTENANCE_STATE that allows bypassing the maintenance state filter for devices, similar to the existing INVENTORY_IGNORE_PROVISION_STATE option.

AI-assisted: Claude Code