### PR TITLE
Stage ansible.cfg via rsync for atomic updates

### DIFF
--- a/files/merge-ansible-cfg.py
+++ b/files/merge-ansible-cfg.py
@@ -19,7 +19,7 @@ from loguru import logger
 # Constants
 DEFAULT_CONFIG_PATH = Path("/defaults/ansible.cfg")
 USER_CONFIG_PATH = Path("/opt/configuration/environments/ansible.cfg")
-OUTPUT_CONFIG_PATH = Path("/inventory/ansible/ansible.cfg")
+OUTPUT_CONFIG_PATH = Path("/inventory.merge/ansible/ansible.cfg")
 
 # Logger configuration
 LOGGER_FORMAT = (

--- a/files/run.sh
+++ b/files/run.sh
@@ -81,7 +81,11 @@ python3 /generate-minified-hosts.py
 rsync -q -a /inventory.pre/host_vars/ /inventory.merge/fast/host_vars/ 2>/dev/null || true
 rsync -q -a /inventory.pre/group_vars/ /inventory.merge/fast/group_vars/ 2>/dev/null || true
 
-rsync -q -a --delete --exclude .git /inventory.merge/ /inventory
+# Render ansible.cfg into the staging tree so it arrives atomically via
+# the rsync below (no absent-window for concurrent readers).
+python3 /merge-ansible-cfg.py
+
+rsync -q -a --delete --delay-updates --exclude .git /inventory.merge/ /inventory
 
 pushd /inventory > /dev/null || exit 1
 
@@ -100,9 +104,6 @@ if [[ $(git status --porcelain --untracked-files=no | wc -l) != 0 || ! -e /inven
     mkdir -p /inventory/clustershell
     python3 /generate-clustershell-ansible-file.py
 fi
-
-mkdir -p /inventory/ansible
-python3 /merge-ansible-cfg.py
 
 if [[ $(git status --porcelain) ]]; then
     git add -A


### PR DESCRIPTION
## Summary

- Render `ansible.cfg` into `/inventory.merge/ansible/` so it ships as part of the staging-tree rsync rather than being written directly into `/inventory/ansible/` after the rsync completes.
- Add `--delay-updates` to the `/inventory.merge/ → /inventory` rsync so consumers see an atomic `renameat` swap of each file, including `ansible.cfg`.
- Drop the now-unnecessary post-rsync `mkdir -p /inventory/ansible` + `python3 /merge-ansible-cfg.py` sequence.

## Why

The previous ordering had a short window (tens to hundreds of milliseconds) in which `/inventory/ansible/ansible.cfg` did not exist: the `rsync --delete` at `run.sh:84` removed the previous copy, and `merge-ansible-cfg.py` at `run.sh:105` had not yet rewritten it. Consumer containers (`osism-ansible`, `kolla-ansible` for 2023.2 / 2024.1 / 2024.2 / 2025.1 / 2025.2, `ceph-ansible`) that resolved `ANSIBLE_CONFIG` during that window silently fell through to the image-baked `/etc/ansible/ansible.cfg`, which carries a stale `private_key_file` pointer, producing `UNREACHABLE` on gather-facts and a silently corrupt fact cache for the rest of the deploy.

With the merge staged before the rsync and `--delay-updates` engaged, the live `ansible.cfg` transitions old → new via a single atomic `rename(2)`; there is no absent window. No consumer-side change is required — all three container families use the same three-tier ladder against `/ansible/inventory/ansible/ansible.cfg`.

## Recent CI evidence

Five most recent hits of the `ok=1 changed=0 ... ignored=1` PLAY RECAP fingerprint in `osism/testbed` Zuul periodic jobs (sweep run 2026-04-22):

| Date | UUID | Job | Log |
|---|---|---|---|
| 2026-04-22 | `b65aed14` | `testbed-deploy-current-in-a-nutshell-with-tempest-ubuntu-24.04` | https://logs.services.osism.tech/b65/osism/b65aed14c9df4fc6a843f034b5ab63a5/ |
| 2026-04-22 | `b8d90e36` | `testbed-deploy-next-in-a-nutshell-with-tempest-ubuntu-24.04` | https://logs.services.osism.tech/b8d/osism/b8d90e36115f486386f7c62f5e48a27f/ |
| 2026-04-21 | `f871de0e` | `testbed-deploy-next-in-a-nutshell-with-tempest-ubuntu-24.04` | https://logs.services.osism.tech/f87/osism/f871de0e9edf4d3eaf1997946d17c1df/ |
| 2026-04-20 | `0c547945` | `testbed-deploy-current-in-a-nutshell-with-tempest-ubuntu-24.04` | https://logs.services.osism.tech/0c5/osism/0c547945e3c249e19555e011f583bccb/ |
| 2026-04-19 | `233cebef` | `testbed-deploy-current-in-a-nutshell-with-tempest-ubuntu-24.04` | https://logs.services.osism.tech/233/osism/233cebefaf8f44b2921355cd5995b046/ |

Each build shows all 7 testbed hosts returning `ok=1 changed=0 ... ignored=1` from `osism apply gather-facts`, matching the byte-for-byte reproducer of the `ANSIBLE_CONFIG` fall-through (confirmed at ends of the longer sweep window via `grep '/ansible/secrets/id_rsa'` against the build logs). Several of the hits progressed past k3s-join because the 20-retry loop absorbed the loopback symptom, then failed on an unrelated tempest regression — the fact cache was still silently corrupt for the entire build.

## Test plan

- [ ] Rebuild `container-image-inventory-reconciler` from this branch.
- [ ] Run `contrib/operator-loop.py` (in `osism/testbed`) against a fresh-deploy cloudpod to exercise the reconciler/consumer race over multiple cycles.
- [ ] With a tight `stat`/`inotify` watcher on `/ansible/inventory/ansible/ansible.cfg` during a reconciler cycle, confirm the file is never absent (only ever replaced).
- [ ] Confirm no gather-facts `UNREACHABLE` recaps attributable to the silent `ANSIBLE_CONFIG` fall-through during repeated deploy loops.

## Notes

- Companion hygiene fixes (strip the stale `private_key_file` line from the three image-default `ansible.cfg` files, fail-loud guard on `ANSIBLE_CONFIG` in `run-generic.sh`, drop `ignore_unreachable: true` from `gather-facts.yml`) are tracked separately and do not depend on this change; this PR removes the race at its source.
- The sibling post-rsync writer `generate-clustershell-ansible-file.py` at `run.sh:101` opens a smaller window for clustershell consumers. It is not currently biting the silent-cache-miss bug (no gather-facts path reads `/inventory/clustershell/`), but the same staging pattern would close it and is worth a follow-up PR.