### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -50,7 +50,7 @@ set -x
 
 git clone https://github.com/osism/release /release
 git clone https://github.com/osism/defaults /defaults
-git clone https://github.com/osism/cfg-generics /generics
+git clone https://github.com/osism/generics /generics
 
 if [ "$VERSION" != "latest" ]; then
   ( cd /release || exit; git fetch --all --force; git checkout "inventory-reconciler-$VERSION" )

--- a/files/change.sh
+++ b/files/change.sh
@@ -10,7 +10,7 @@ if [[ "$1" == "defaults" ]]; then
     git clone --depth 1 -b $2 https://github.com/osism/defaults /defaults
 elif [[ "$1" == "generics" ]]; then
     rm -rf /generics
-    git clone --depth 1 -b $2 https://github.com/osism/cfg-generics /generics
+    git clone --depth 1 -b $2 https://github.com/osism/generics /generics
 
     rm -rf /inventory.generics/
     mkdir -p /inventory.generics/

--- a/files/netbox/main.py
+++ b/files/netbox/main.py
@@ -5,7 +5,7 @@
 This script reads all required systems from the NetBox and writes them
 into a form that can be evaluated by the Ansible Inventory Plugin INI.
 
-This is a workaround to use the groups defined in cfg-generics without
+This is a workaround to use the groups defined in generics without
 having to import them into NetBox.
 """
 

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -32,7 +32,7 @@
           set -x
 
           # This is a way to use this job also in other repositories
-          # (osism/cfg-generics, osism/defaults, ..). The assumption
+          # (osism/generics, osism/defaults, ..). The assumption
           # is that if no Containerfile is available, the job was executed
           # from one of the other repositories. There are probably more
           # elegant ways to solve this, but it is good enough for now.


### PR DESCRIPTION
## Summary
- `osism/cfg-generics` was renamed to `osism/generics`. Update all live refs (Containerfile and `files/change.sh` clone URLs) and two explanatory comments (`files/netbox/main.py`, `playbooks/build.yml`).
- GitHub's rename alias keeps the old URLs working, so no behavior change is expected.

## Test plan
- [ ] Image build succeeds; `/generics` is populated from `osism/generics`
- [ ] `change.sh generics <branch>` clones from the new URL