### PR TITLE
Add pytest foundation for files/netbox/ unit tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -81,6 +81,10 @@
       docker_registry: osism.harbor.regio.digital
 
 - job:
+    name: container-image-inventory-reconciler-unit-tests
+    run: playbooks/test-unit.yml
+
+- job:
     name: abstract-container-image-inventory-reconciler-push
     abstract: true
     semaphores:
@@ -111,18 +115,21 @@
         - hadolint
         - yamllint
         - container-image-inventory-reconciler-build
+        - container-image-inventory-reconciler-unit-tests
     gate:
       jobs:
         - ansible-lint
         - flake8
         - hadolint
         - yamllint
+        - container-image-inventory-reconciler-unit-tests
     periodic-daily:
       jobs:
         - ansible-lint
         - flake8
         - hadolint
         - yamllint
+        - container-image-inventory-reconciler-unit-tests
     periodic-midnight:
       jobs:
         - container-image-inventory-reconciler-push

--- a/README.md
+++ b/README.md
@@ -2,3 +2,23 @@
 
 [![Quay](https://img.shields.io/badge/Quay-osism%2Finventory--reconciler-blue.svg)](https://quay.io/repository/osism/inventory-reconciler)
 [![Documentation](https://img.shields.io/static/v1?label=&message=documentation&color=blue)](https://osism.tech/docs/guides/configuration-guide/inventory#reconciler)
+
+## Running unit tests
+
+The Python sources under `files/netbox/` ship with a unit-test suite under
+`tests/unit/`. The Zuul `container-image-inventory-reconciler-unit-tests`
+job runs the suite in `check`, `gate`, and `periodic-daily`.
+
+To run the tests locally:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r files/requirements.txt -r files/test-requirements.txt
+.venv/bin/pytest tests/unit
+```
+
+Run a single test file:
+
+```bash
+.venv/bin/pytest tests/unit/netbox/test_smoke.py
+```

--- a/files/test-requirements.txt
+++ b/files/test-requirements.txt
@@ -1,0 +1,10 @@
+# Test framework
+pytest==8.4.2
+pytest-cov==6.0.0
+pytest-mock==3.14.1
+
+# Runtime dependency of files/netbox/ that is not in files/requirements.txt
+# because it is pulled in transitively via the osism package at container
+# build time. The unit-test environment installs only files/requirements.txt
+# (no osism), so we need to declare loguru explicitly here.
+loguru==0.7.3

--- a/playbooks/test-unit.yml
+++ b/playbooks/test-unit.yml
@@ -1,0 +1,42 @@
+---
+- name: Run unit tests for files/netbox/
+  hosts: all
+
+  vars:
+    python_venv_dir: /tmp/test-unit-venv
+
+  tasks:
+    - name: Ensure python3-venv is available
+      become: true
+      ansible.builtin.package:
+        name:
+          - python3-venv
+        state: present
+
+    - name: Create virtualenv and install dependencies
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          python3 -m venv "{{ python_venv_dir }}"
+          "{{ python_venv_dir }}/bin/pip" install --upgrade pip
+          "{{ python_venv_dir }}/bin/pip" install \
+              -r files/requirements.txt \
+              -r files/test-requirements.txt
+      changed_when: true
+
+    - name: Run pytest
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          "{{ python_venv_dir }}/bin/pytest" tests/unit
+      changed_when: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+testpaths = ["tests/unit"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-ra --strict-markers"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared pytest fixtures and path setup for unit tests.
+
+The Python sources under ``files/netbox/`` are not packaged. They are copied
+into the container image at ``/netbox/`` and run as scripts (``python main.py``).
+Imports inside the package are unqualified (``from utils import ...``,
+``from config import ...``), so we add ``files/netbox/`` to ``sys.path`` here
+to mirror the runtime layout.
+"""
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_NETBOX_SRC = _REPO_ROOT / "files" / "netbox"
+
+if str(_NETBOX_SRC) not in sys.path:
+    sys.path.insert(0, str(_NETBOX_SRC))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/netbox/__init__.py
+++ b/tests/unit/netbox/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/netbox/test_smoke.py
+++ b/tests/unit/netbox/test_smoke.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests verifying the test infrastructure is wired up correctly.
+
+These tests exist so a regression in the harness (broken sys.path, missing
+runtime dependency, import-time crash in a netbox module) fails CI loudly
+before any per-module test suite runs.
+"""
+
+import utils
+from exceptions import NetBoxAPIError, NetBoxConnectionError, NetBoxException
+
+
+def test_deep_merge_is_callable():
+    assert callable(utils.deep_merge)
+
+
+def test_deep_merge_basic():
+    assert utils.deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+
+def test_netbox_exception_hierarchy():
+    assert issubclass(NetBoxConnectionError, NetBoxException)
+    assert issubclass(NetBoxAPIError, NetBoxException)


### PR DESCRIPTION
Establishes the test harness so per-module unit-test sub-issues from #524 can land. No coverage of existing code yet — that is tracked separately.

- files/test-requirements.txt: pinned pytest, pytest-cov, pytest-mock; plus loguru, which files/netbox/ imports but which is not in files/requirements.txt because the container build pulls it in transitively via the osism package.
- pyproject.toml: minimal pytest config (testpaths, strict markers; no coverage threshold).
- tests/conftest.py: prepends files/netbox/ to sys.path so the package's unqualified imports (from utils import ..., from config import ...) resolve in the test environment, mirroring the runtime layout where the tree is copied to /netbox/ and run as scripts.
- tests/unit/netbox/test_smoke.py: minimal smoke test that exercises utils.deep_merge and the NetBox exception hierarchy so a regression in the harness fails CI loudly before any real test suite runs.
- playbooks/test-unit.yml + container-image-inventory-reconciler-unit-tests Zuul job, wired into check, gate, and periodic-daily.
- README.md: short section on running the tests locally.

Tests live at the repo root in tests/, outside files/netbox/, so the existing Containerfile COPY of files/netbox/ does not pull them into the image.

Closes #525

AI-assisted: Claude Code