### PR TITLE
Close cycle=0 ansible.cfg startup window

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -70,6 +70,13 @@ if [[ -e /inventory.pre/99-overwrite ]]; then
 fi
 python3 /merge-inventory-files.py
 
+# Publish ansible.cfg before the slow ansible-inventory render so cycle=0
+# consumers do not fall through to the image-default config while /inventory is
+# still empty. The final rsync re-carries the file with --delay-updates for
+# cycle>=1 atomic updates.
+python3 /merge-ansible-cfg.py
+rsync -q -a --delay-updates /inventory.merge/ansible/ /inventory/ansible/
+
 # The intermediate step via the inventory.merge directory
 # is necessary to remove other files in /inventory via -delete.
 ansible-inventory -i /inventory.pre --list -y --output /inventory.merge/hosts.yml
@@ -80,10 +87,6 @@ python3 /generate-minified-hosts.py
 # This avoids parsing the monolithic YAML and enables lazy loading of host_vars.
 rsync -q -a /inventory.pre/host_vars/ /inventory.merge/fast/host_vars/ 2>/dev/null || true
 rsync -q -a /inventory.pre/group_vars/ /inventory.merge/fast/group_vars/ 2>/dev/null || true
-
-# Render ansible.cfg into the staging tree so it arrives atomically via
-# the rsync below (no absent-window for concurrent readers).
-python3 /merge-ansible-cfg.py
 
 rsync -q -a --delete --delay-updates --exclude .git /inventory.merge/ /inventory
 


### PR DESCRIPTION
## Summary

PR #521 closed the recurring cycle>=1 `ansible.cfg` absent-window by staging
that file before the final rsync and carrying it with `--delay-updates`.

The initial reconciliation cycle still has a separate startup gap, though:
`/inventory` starts empty and `ansible.cfg` is only published after the slow
`ansible-inventory --list` render completes. On slower CI workers, consumers can
resolve `ANSIBLE_CONFIG` during that gap, fall through to the image-default
`/etc/ansible/ansible.cfg`, pick up the stale `private_key_file`, and reproduce
the silent gather-facts cache-miss fingerprint.

## Recent CI instances

  The cycle=0 window has been hitting `testbed-upgrade-stable-next-ubuntu-24.04`
  intermittently since PR #521 shipped. Two confirmed recent occurrences:

  - **2026-05-15** build
    [`b52de440`](https://logs.services.osism.tech/b52/osism/b52de440b7304c369e5f761c4cd64072/)
    — `gather-facts` PLAY RECAP shows `ok=1 skipped=1 ignored=1` for all 7 hosts.
    `manager.service` restarted at 03:04:27 UTC; `osism apply gather-facts` fired
    at 03:05:47 UTC — 1 second after `osism-ansible` became healthy (satisfying the
    reconciler's `depends_on`), so the reconciler had just started its first cycle.
  - **2026-05-11** build
    [`fca454bc`](https://logs.services.osism.tech/fca/osism/fca454bc7a63495d8cad22d079c0e214/)
    — same signature, same 1-second gap between `osism-ansible` healthy and
    `gather-facts` dispatch.

  Both runs used the PR #521 image. `fluentd-registry-miss` failures on the
  intervening days (May 7–10, 13–14) confirm gather-facts passed on those days —
  the race is load-dependent on `ansible-inventory` render time.

## Change

Publish the merged `ansible.cfg` immediately after the input inventory has been
prepared, before the expensive inventory render begins. The final staged rsync
still re-carries the same file with `--delay-updates`, so the cycle>=1 atomic
update behavior from #521 remains unchanged.

## Why this shape

This closes the remaining cycle=0 path at the writer side without relying on
consumer timing or orchestration waits. It deliberately publishes only the
config file early; the full inventory tree is still built and committed by the
existing final rsync.

## Validation notes

The prior TRACE validation for #521 measured cycle=0 with `ansible.cfg` absent
from reconciler start until the first final rsync. This change moves the publish
point ahead of the measured slow step in that path.