### PR TITLE
Generate Netplan bond interfaces from NetBox LAGs

### DIFF
--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -117,6 +117,15 @@ The `999-netbox-netplan.yml` file contains netplan_parameters which can be:
     - All IPv4 and IPv6 addresses assigned to the interface are included
     - If the VRF has a table ID, the interface is added to the VRF's interface list in `network_vrfs`
     - The interface is configured in `network_dummy_devices`
+  - **Bond / Port Channel interfaces (LAG)**: Interfaces of type `lag` with the `managed-by-osism` tag (uses the same NetBox modelling as SONiC port channel detection)
+    - The label (or name if no label) becomes the bond name in `network_bonds`
+    - Member interfaces are detected via their `lag` back-reference (i.e. the interface's `lag` field points at the LAG interface)
+    - Members are rendered as regular `network_ethernets` entries (MAC `match` + `set-name`) but carry **no** addresses, DHCP or leaf link-local settings — the bond interface holds the IP configuration
+    - IP addresses and MTU are taken from the LAG interface itself
+    - Defaults to an LACP (802.3ad) port channel: `mode: 802.3ad`, `lacp-rate: fast`, `mii-monitor-interval: 100`, `transmit-hash-policy: layer3+4`
+    - The parameters (and any other bond key) can be overridden per LAG via the `netplan_parameters` custom field on the LAG interface. Providing a `parameters` dict replaces the auto-generated defaults entirely (e.g. to switch to `active-backup` with a `primary` member)
+    - If the LAG interface is assigned to a VRF, the bond is added to the VRF's interface list in `network_vrfs`
+    - The interface is configured in `network_bonds`
   - Example output:
     ```yaml
     network_dummy_devices:
@@ -137,6 +146,29 @@ The `999-netbox-netplan.yml` file contains netplan_parameters which can be:
         addresses:
           - 10.0.0.5/24
           - 2001:db8::5/64
+      eno8303:
+        match:
+          macaddress: "aa:bb:cc:00:00:01"
+        set-name: eno8303
+        mtu: 9100
+      eno8403:
+        match:
+          macaddress: "aa:bb:cc:00:00:02"
+        set-name: eno8403
+        mtu: 9100
+    network_bonds:
+      bond0:
+        interfaces:
+          - eno8303
+          - eno8403
+        parameters:
+          mode: 802.3ad
+          lacp-rate: fast
+          mii-monitor-interval: 100
+          transmit-hash-policy: layer3+4
+        mtu: 9100
+        addresses:
+          - 10.0.0.5/24
     network_vlans:
       vlan100:
         id: 100

--- a/files/netbox/CLAUDE.md
+++ b/files/netbox/CLAUDE.md
@@ -118,13 +118,16 @@ The `999-netbox-netplan.yml` file contains netplan_parameters which can be:
     - If the VRF has a table ID, the interface is added to the VRF's interface list in `network_vrfs`
     - The interface is configured in `network_dummy_devices`
   - **Bond / Port Channel interfaces (LAG)**: Interfaces of type `lag` with the `managed-by-osism` tag (uses the same NetBox modelling as SONiC port channel detection)
+    - **LAG eligibility**: the LAG interface must have the `managed-by-osism` tag, be **enabled**, **not** `mgmt_only`, and have a label or name. A `mgmt_only` or disabled LAG is not emitted as a bond
     - The label (or name if no label) becomes the bond name in `network_bonds`
-    - Member interfaces are detected via their `lag` back-reference (i.e. the interface's `lag` field points at the LAG interface)
-    - Members are rendered as regular `network_ethernets` entries (MAC `match` + `set-name`) but carry **no** addresses, DHCP or leaf link-local settings — the bond interface holds the IP configuration
-    - IP addresses and MTU are taken from the LAG interface itself
+    - **Member eligibility**: a member is detected via its `lag` back-reference (its `lag` field points at the LAG interface), but the back-reference alone is **not** sufficient — the member must *independently* pass the same gates as a regular ethernet: it must carry the `managed-by-osism` tag, have a MAC address **and** label, be **enabled**, and **not** be `mgmt_only`
+      - A member that fails any gate is dropped from the bond (and logged); a disabled member is dropped entirely rather than emitted as a standalone `activation-mode: off` ethernet
+      - If a managed LAG ends up with **no** eligible members, the bond is skipped with a warning (an empty `interfaces` list is invalid netplan)
+    - Members are rendered as regular `network_ethernets` entries (MAC `match` + `set-name`) but carry **no** addresses, DHCP or leaf link-local settings — the bond interface holds the IP configuration. A member's `netplan_parameters` custom field may tune other keys, but `match`/`set-name` and any L3/link-local keys (`addresses`, `dhcp4`, `dhcp6`, `link-local`) are ignored for members
+    - IP addresses and MTU are taken from the LAG interface itself. Bonds are always expected to be IP-carrying and therefore — unlike regular ethernets — never receive the leaf / unnumbered treatment (`link-local: [ipv6]`, `dhcp4/6: false`)
     - Defaults to an LACP (802.3ad) port channel: `mode: 802.3ad`, `lacp-rate: fast`, `mii-monitor-interval: 100`, `transmit-hash-policy: layer3+4`
-    - The parameters (and any other bond key) can be overridden per LAG via the `netplan_parameters` custom field on the LAG interface. Providing a `parameters` dict replaces the auto-generated defaults entirely (e.g. to switch to `active-backup` with a `primary` member)
-    - If the LAG interface is assigned to a VRF, the bond is added to the VRF's interface list in `network_vrfs`
+    - The parameters (and any other bond key except `interfaces`) can be overridden per LAG via the `netplan_parameters` custom field on the LAG interface. Providing a `parameters` dict replaces the auto-generated defaults entirely (e.g. to switch to `active-backup` with a `primary` member). The auto-detected `interfaces` membership is authoritative and cannot be overridden by the custom field
+    - If the LAG interface is assigned to a VRF, the bond is added to the VRF's interface list in `network_vrfs` (a VRF assigned to a *member* is ignored — only the bond carries L3 config)
     - The interface is configured in `network_bonds`
   - Example output:
     ```yaml

--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -13,6 +13,14 @@ from utils import deep_merge
 from .base_extractor import BaseExtractor
 
 
+# Keys a bond member's netplan_parameters custom field must never override:
+# the MAC-rename identity (match / set-name) and any L3 / link-local config -
+# the bond interface, not its members, carries the IP configuration.
+_MEMBER_PROTECTED_KEYS = frozenset(
+    {"match", "set-name", "addresses", "dhcp4", "dhcp6", "link-local"}
+)
+
+
 class NetplanExtractor(BaseExtractor):
     """Extracts netplan parameters from NetBox devices."""
 
@@ -75,6 +83,76 @@ class NetplanExtractor(BaseExtractor):
         except Exception:
             return False
 
+    def _collect_addresses(self, interface: Any) -> List[str]:
+        """Return all IP addresses (with prefix) assigned to an interface."""
+        addresses: List[str] = []
+        try:
+            for ip in self.bulk_loader.get_interface_ip_addresses(interface):
+                if ip.address:
+                    addresses.append(ip.address)
+        except Exception:
+            pass
+        return addresses
+
+    def _resolve_mtu(self, interface: Any, effective_default_mtu: int) -> int:
+        """Return the interface's MTU if set, otherwise the effective default."""
+        if hasattr(interface, "mtu") and interface.mtu:
+            return interface.mtu
+        return effective_default_mtu
+
+    def _get_netplan_parameters(self, interface: Any) -> Optional[Dict[str, Any]]:
+        """Return the interface's netplan_parameters custom field, if a dict."""
+        if not (hasattr(interface, "custom_fields") and interface.custom_fields):
+            return None
+        params = interface.custom_fields.get("netplan_parameters")
+        if params and isinstance(params, dict):
+            return params
+        return None
+
+    def _apply_netplan_overrides(
+        self,
+        config: Dict[str, Any],
+        params: Dict[str, Any],
+        *,
+        protected: frozenset = frozenset(),
+        context: str = "",
+    ) -> None:
+        """Shallow-merge custom-field overrides into config.
+
+        Keys listed in ``protected`` are skipped and logged, so a custom field
+        can neither break an interface's identity nor reintroduce config that
+        the interface type must not carry.
+        """
+        for key, value in params.items():
+            if key in protected:
+                logger.warning(
+                    f"Ignoring '{key}' in netplan_parameters override for {context}"
+                )
+                continue
+            config[key] = value
+
+    def _register_vrf_membership(
+        self,
+        interface_id: Any,
+        member_name: str,
+        interface_vrf_assignments: Dict[Any, Any],
+        network_vrfs: Dict[str, Any],
+        device_name: str,
+    ) -> None:
+        """Add ``member_name`` to its VRF's interface list when a VRF is set."""
+        if interface_id not in interface_vrf_assignments:
+            return
+        vrf_name, vrf_table = interface_vrf_assignments[interface_id]
+        vrf_entry = network_vrfs.setdefault(
+            vrf_name, {"table": vrf_table, "interfaces": []}
+        )
+        if member_name not in vrf_entry["interfaces"]:
+            vrf_entry["interfaces"].append(member_name)
+            logger.debug(
+                f"Added interface {member_name} to VRF {vrf_name} "
+                f"(table {vrf_table}) for device {device_name}"
+            )
+
     def extract(
         self, device: Any, default_mtu: int = 9100, **kwargs
     ) -> Optional[Dict[str, Any]]:
@@ -96,11 +174,19 @@ class NetplanExtractor(BaseExtractor):
         - If assigned to a VRF, the interface is added to the VRF's interface list
 
         For LAG / bond / port channel interfaces (type=lag):
-        - Must have "managed-by-osism" tag
-        - Generates a network_bonds entry; member interfaces (those whose "lag"
-          field points at the LAG) are renamed via their MAC but carry no IPs
+        - The LAG itself must have the "managed-by-osism" tag, be enabled and not
+          mgmt_only, and have a label or name (same gates as every other type)
+        - Generates a network_bonds entry; a member interface is included only if
+          it points at the LAG via its "lag" field AND independently passes the
+          tag, MAC+label, enabled and mgmt_only gates - ineligible members are
+          dropped (and logged), and a LAG with no eligible members is skipped
+        - Members are renamed via their MAC but carry no IPs/DHCP; the bond
+          interface always holds the IP configuration (bonds never receive the
+          leaf / unnumbered treatment - they are expected to be IP-carrying here)
         - Defaults to an LACP (802.3ad) bond; override the parameters per LAG via
-          the netplan_parameters custom field (e.g. to switch to active-backup)
+          the netplan_parameters custom field (e.g. to switch to active-backup).
+          The auto-detected "interfaces" membership is authoritative and cannot
+          be overridden by the custom field
 
         If device.config_context contains a "netplan_parameters" key, its values
         are deep-merged into the auto-generated parameters. Since config_context
@@ -174,13 +260,34 @@ class NetplanExtractor(BaseExtractor):
         # detection relies on.
         lag_interfaces_by_id = {}
         for interface in interfaces:
-            if (
+            if not (
                 interface.type
                 and interface.type.value == "lag"
                 and getattr(interface, "tags", None)
                 and "managed-by-osism" in [tag.slug for tag in interface.tags]
             ):
-                lag_interfaces_by_id[interface.id] = interface
+                continue
+
+            # Apply the same eligibility gates the main loop uses for every
+            # other interface type. A mgmt_only or disabled LAG must not be
+            # emitted as an active bond, and a LAG with neither label nor name
+            # cannot be addressed.
+            if getattr(interface, "mgmt_only", False):
+                logger.debug(
+                    f"Skipping mgmt_only LAG {interface.name or interface.id} "
+                    f"on device {device.name}"
+                )
+                continue
+            if not getattr(interface, "enabled", True):
+                logger.debug(
+                    f"Skipping disabled LAG {interface.name or interface.id} "
+                    f"on device {device.name}"
+                )
+                continue
+            if not (interface.label or interface.name):
+                continue
+
+            lag_interfaces_by_id[interface.id] = interface
 
         for interface in interfaces:
             # Check if interface has managed-by-osism tag
@@ -281,25 +388,20 @@ class NetplanExtractor(BaseExtractor):
                 )
 
                 # Process VRF assignment
-                if interface.id in interface_vrf_assignments:
-                    vrf_name, vrf_table = interface_vrf_assignments[interface.id]
-                    # Initialize VRF entry if not exists
-                    if vrf_name not in network_vrfs:
-                        network_vrfs[vrf_name] = {
-                            "table": vrf_table,
-                            "interfaces": [],
-                        }
-                    # Add VXLAN interface to VRF's interface list
-                    if interface_name not in network_vrfs[vrf_name]["interfaces"]:
-                        network_vrfs[vrf_name]["interfaces"].append(interface_name)
-                        logger.debug(
-                            f"Added VXLAN interface {interface_name} to VRF {vrf_name} (table {vrf_table}) for device {device.name}"
-                        )
+                self._register_vrf_membership(
+                    interface.id,
+                    interface_name,
+                    interface_vrf_assignments,
+                    network_vrfs,
+                    device.name,
+                )
                 continue
 
-            # LAG / bond / port channel interfaces are processed after the main
-            # loop (members may appear before or after the LAG interface itself).
-            if interface.id in lag_interfaces_by_id:
+            # LAG / bond / port channel interfaces are never emitted as
+            # ethernets: eligible ones are processed in the dedicated post-loop
+            # pass (members may appear before or after the LAG itself), and
+            # ineligible ones (mgmt_only / disabled / nameless) are dropped here.
+            if interface.type and interface.type.value == "lag":
                 continue
 
             # Check if this is a virtual interface (VLAN or VRF dummy)
@@ -333,69 +435,30 @@ class NetplanExtractor(BaseExtractor):
                             }
 
                             # Use parent interface's MTU if available, otherwise use effective default
-                            if (
-                                hasattr(interface.parent, "mtu")
-                                and interface.parent.mtu
-                            ):
-                                vlan_config["mtu"] = interface.parent.mtu
-                            else:
-                                vlan_config["mtu"] = effective_default_mtu
+                            vlan_config["mtu"] = self._resolve_mtu(
+                                interface.parent, effective_default_mtu
+                            )
 
                             # Get IP addresses for this VLAN interface
-                            addresses = []
-                            try:
-                                ip_addresses = (
-                                    self.bulk_loader.get_interface_ip_addresses(
-                                        interface
-                                    )
-                                )
-                                for ip in ip_addresses:
-                                    if ip.address:
-                                        addresses.append(ip.address)
-                            except Exception:
-                                pass
-
+                            addresses = self._collect_addresses(interface)
                             if addresses:
                                 vlan_config["addresses"] = addresses
 
                             # Check for interface-specific netplan_parameters custom field
-                            if (
-                                hasattr(interface, "custom_fields")
-                                and interface.custom_fields
-                            ):
-                                interface_netplan_params = interface.custom_fields.get(
-                                    "netplan_parameters"
-                                )
-                                if interface_netplan_params and isinstance(
-                                    interface_netplan_params, dict
-                                ):
-                                    # Merge interface-specific parameters into the VLAN config
-                                    vlan_config.update(interface_netplan_params)
+                            vlan_params = self._get_netplan_parameters(interface)
+                            if vlan_params:
+                                self._apply_netplan_overrides(vlan_config, vlan_params)
 
                             network_vlans[vlan_name] = vlan_config
 
                             # Process VRF assignment if interface was successfully added
-                            if interface.id in interface_vrf_assignments:
-                                vrf_name, vrf_table = interface_vrf_assignments[
-                                    interface.id
-                                ]
-                                # Initialize VRF entry if not exists
-                                if vrf_name not in network_vrfs:
-                                    network_vrfs[vrf_name] = {
-                                        "table": vrf_table,
-                                        "interfaces": [],
-                                    }
-                                # Add VLAN interface to VRF's interface list
-                                if (
-                                    vlan_name
-                                    not in network_vrfs[vrf_name]["interfaces"]
-                                ):
-                                    network_vrfs[vrf_name]["interfaces"].append(
-                                        vlan_name
-                                    )
-                                    logger.debug(
-                                        f"Added VLAN interface {vlan_name} to VRF {vrf_name} (table {vrf_table}) for device {device.name}"
-                                    )
+                            self._register_vrf_membership(
+                                interface.id,
+                                vlan_name,
+                                interface_vrf_assignments,
+                                network_vrfs,
+                                device.name,
+                            )
                 elif (
                     hasattr(interface, "vrf")
                     and interface.vrf
@@ -418,6 +481,16 @@ class NetplanExtractor(BaseExtractor):
 
             # Use label as the interface name
             label = interface.label
+
+            # Determine LAG membership up front so the disabled-interface and
+            # custom-field handling below can be member-aware.
+            lag_parent_id = (
+                interface.lag.id if getattr(interface, "lag", None) else None
+            )
+            is_lag_member = (
+                lag_parent_id is not None and lag_parent_id in lag_interfaces_by_id
+            )
+
             interface_config = {
                 "match": {"macaddress": interface.mac_address.lower()},
                 "set-name": label,
@@ -426,28 +499,44 @@ class NetplanExtractor(BaseExtractor):
             # Check if interface is disabled
             is_enabled = getattr(interface, "enabled", True)
             if not is_enabled:
+                if is_lag_member:
+                    # A disabled member is dropped from the bond entirely.
+                    # Emitting it as a standalone activation-mode: off ethernet
+                    # would orphan it from the bond's interfaces list.
+                    logger.debug(
+                        f"Skipping disabled member {label} of LAG "
+                        f"{lag_interfaces_by_id[lag_parent_id].name} "
+                        f"on device {device.name}"
+                    )
+                    continue
                 # For disabled interfaces, only set basic config and mark as down
                 interface_config["activation-mode"] = "off"
                 network_ethernets[label] = interface_config
                 continue
 
             # Add MTU - use interface MTU if set, otherwise use effective default
-            if hasattr(interface, "mtu") and interface.mtu:
-                interface_config["mtu"] = interface.mtu
-            else:
-                interface_config["mtu"] = effective_default_mtu
+            interface_config["mtu"] = self._resolve_mtu(
+                interface, effective_default_mtu
+            )
 
             # Bond / port channel members only need the MAC-based rename and the
             # MTU here. The bond interface itself carries the IP configuration, so
-            # members must not get addresses, DHCP or leaf link-local settings.
-            lag_parent_id = (
-                interface.lag.id if getattr(interface, "lag", None) else None
-            )
-            if lag_parent_id is not None and lag_parent_id in lag_interfaces_by_id:
-                if hasattr(interface, "custom_fields") and interface.custom_fields:
-                    member_params = interface.custom_fields.get("netplan_parameters")
-                    if member_params and isinstance(member_params, dict):
-                        interface_config.update(member_params)
+            # members must not get addresses, DHCP or leaf link-local settings -
+            # a member's custom field cannot reintroduce those or break its
+            # MAC-rename identity (see _MEMBER_PROTECTED_KEYS).
+            if is_lag_member:
+                member_params = self._get_netplan_parameters(interface)
+                if member_params:
+                    self._apply_netplan_overrides(
+                        interface_config,
+                        member_params,
+                        protected=_MEMBER_PROTECTED_KEYS,
+                        context=(
+                            f"member {label} of LAG "
+                            f"{lag_interfaces_by_id[lag_parent_id].name} "
+                            f"on device {device.name}"
+                        ),
+                    )
                 network_ethernets[label] = interface_config
                 bond_members.setdefault(lag_parent_id, []).append(label)
                 logger.debug(
@@ -457,15 +546,7 @@ class NetplanExtractor(BaseExtractor):
                 continue
 
             # Get IP addresses for this interface
-            addresses = []
-            try:
-                ip_addresses = self.bulk_loader.get_interface_ip_addresses(interface)
-                for ip in ip_addresses:
-                    if ip.address:
-                        addresses.append(ip.address)
-            except Exception:
-                pass
-
+            addresses = self._collect_addresses(interface)
             if addresses:
                 interface_config["addresses"] = addresses
 
@@ -480,49 +561,27 @@ class NetplanExtractor(BaseExtractor):
                 interface_config["dhcp6"] = False
 
             # Check for interface-specific netplan_parameters custom field
-            if hasattr(interface, "custom_fields") and interface.custom_fields:
-                interface_netplan_params = interface.custom_fields.get(
-                    "netplan_parameters"
-                )
-                if interface_netplan_params and isinstance(
-                    interface_netplan_params, dict
-                ):
-                    # Merge interface-specific parameters into the interface config
-                    interface_config.update(interface_netplan_params)
+            ethernet_params = self._get_netplan_parameters(interface)
+            if ethernet_params:
+                self._apply_netplan_overrides(interface_config, ethernet_params)
 
             network_ethernets[label] = interface_config
 
             # Process VRF assignment if interface was successfully added
-            if interface.id in interface_vrf_assignments:
-                vrf_name, vrf_table = interface_vrf_assignments[interface.id]
-                # Initialize VRF entry if not exists
-                if vrf_name not in network_vrfs:
-                    network_vrfs[vrf_name] = {
-                        "table": vrf_table,
-                        "interfaces": [],
-                    }
-                # Add ethernet interface to VRF's interface list
-                if label not in network_vrfs[vrf_name]["interfaces"]:
-                    network_vrfs[vrf_name]["interfaces"].append(label)
-                    logger.debug(
-                        f"Added ethernet interface {label} to VRF {vrf_name} (table {vrf_table}) for device {device.name}"
-                    )
+            self._register_vrf_membership(
+                interface.id,
+                label,
+                interface_vrf_assignments,
+                network_vrfs,
+                device.name,
+            )
 
         # Add loopback0 configuration if found
         if loopback0_interface:
             loopback0_config = {}
 
             # Get all IP addresses assigned to loopback0 using bulk_loader
-            addresses = []
-            try:
-                ip_addresses = self.bulk_loader.get_interface_ip_addresses(
-                    loopback0_interface
-                )
-                for ip in ip_addresses:
-                    if ip.address:
-                        addresses.append(ip.address)
-            except Exception:
-                pass
+            addresses = self._collect_addresses(loopback0_interface)
 
             # In metalbox mode, always add the default metalbox IPv6 address to loopback0
             reconciler_mode = kwargs.get("reconciler_mode", "manager")
@@ -542,35 +601,28 @@ class NetplanExtractor(BaseExtractor):
                 loopback0_config["addresses"] = addresses
 
             # Add MTU - use interface MTU if set, otherwise use effective default
-            if hasattr(loopback0_interface, "mtu") and loopback0_interface.mtu:
-                loopback0_config["mtu"] = loopback0_interface.mtu
-            else:
-                loopback0_config["mtu"] = effective_default_mtu
+            loopback0_config["mtu"] = self._resolve_mtu(
+                loopback0_interface, effective_default_mtu
+            )
 
-            # Check for interface-specific netplan_parameters custom field
-            if (
-                hasattr(loopback0_interface, "custom_fields")
-                and loopback0_interface.custom_fields
-            ):
-                interface_netplan_params = loopback0_interface.custom_fields.get(
-                    "netplan_parameters"
-                )
-                if interface_netplan_params and isinstance(
-                    interface_netplan_params, dict
-                ):
-                    # Merge interface-specific parameters into the loopback0 config
-                    for key, value in interface_netplan_params.items():
-                        if key == "addresses" and isinstance(value, list):
-                            # Merge addresses lists (avoid duplicates)
-                            if "addresses" in loopback0_config:
-                                for addr in value:
-                                    if addr not in loopback0_config["addresses"]:
-                                        loopback0_config["addresses"].append(addr)
-                            else:
-                                loopback0_config["addresses"] = value
+            # Check for interface-specific netplan_parameters custom field. The
+            # loopback0 merge is address-aware (it unions instead of replacing
+            # addresses), so it does not use the shared override helper.
+            interface_netplan_params = self._get_netplan_parameters(loopback0_interface)
+            if interface_netplan_params:
+                # Merge interface-specific parameters into the loopback0 config
+                for key, value in interface_netplan_params.items():
+                    if key == "addresses" and isinstance(value, list):
+                        # Merge addresses lists (avoid duplicates)
+                        if "addresses" in loopback0_config:
+                            for addr in value:
+                                if addr not in loopback0_config["addresses"]:
+                                    loopback0_config["addresses"].append(addr)
                         else:
-                            # For all other keys, just update normally
-                            loopback0_config[key] = value
+                            loopback0_config["addresses"] = value
+                    else:
+                        # For all other keys, just update normally
+                        loopback0_config[key] = value
 
             if loopback0_config:
                 network_dummy_devices["loopback0"] = loopback0_config
@@ -616,10 +668,9 @@ class NetplanExtractor(BaseExtractor):
                 }
 
                 # Set MTU - use interface MTU if available, otherwise use effective default
-                if hasattr(vxlan_interface, "mtu") and vxlan_interface.mtu:
-                    tunnel_config["mtu"] = vxlan_interface.mtu
-                else:
-                    tunnel_config["mtu"] = effective_default_mtu
+                tunnel_config["mtu"] = self._resolve_mtu(
+                    vxlan_interface, effective_default_mtu
+                )
 
                 # Set local address from loopback0
                 if loopback0_ipv4:
@@ -630,33 +681,14 @@ class NetplanExtractor(BaseExtractor):
                     )
 
                 # Get IP addresses for this VXLAN interface (including VRF-assigned)
-                addresses = []
-                try:
-                    ip_addresses = self.bulk_loader.get_interface_ip_addresses(
-                        vxlan_interface
-                    )
-                    for ip in ip_addresses:
-                        if ip.address:
-                            addresses.append(ip.address)
-                except Exception:
-                    pass
-
+                addresses = self._collect_addresses(vxlan_interface)
                 if addresses:
                     tunnel_config["addresses"] = addresses
 
                 # Check for interface-specific netplan_parameters custom field
-                if (
-                    hasattr(vxlan_interface, "custom_fields")
-                    and vxlan_interface.custom_fields
-                ):
-                    interface_netplan_params = vxlan_interface.custom_fields.get(
-                        "netplan_parameters"
-                    )
-                    if interface_netplan_params and isinstance(
-                        interface_netplan_params, dict
-                    ):
-                        # Merge interface-specific parameters into the tunnel config
-                        tunnel_config.update(interface_netplan_params)
+                vxlan_params = self._get_netplan_parameters(vxlan_interface)
+                if vxlan_params:
+                    self._apply_netplan_overrides(tunnel_config, vxlan_params)
 
                 network_tunnels[vxlan_name] = tunnel_config
                 logger.debug(
@@ -668,38 +700,19 @@ class NetplanExtractor(BaseExtractor):
             dummy_config = {}
 
             # Get IP addresses
-            addresses = []
-            try:
-                ip_addresses = self.bulk_loader.get_interface_ip_addresses(
-                    vrf_dummy_interface
-                )
-                for ip in ip_addresses:
-                    if ip.address:
-                        addresses.append(ip.address)
-            except Exception:
-                pass
-
+            addresses = self._collect_addresses(vrf_dummy_interface)
             if addresses:
                 dummy_config["addresses"] = addresses
 
             # Add MTU - use interface MTU if set, otherwise use effective default
-            if hasattr(vrf_dummy_interface, "mtu") and vrf_dummy_interface.mtu:
-                dummy_config["mtu"] = vrf_dummy_interface.mtu
-            else:
-                dummy_config["mtu"] = effective_default_mtu
+            dummy_config["mtu"] = self._resolve_mtu(
+                vrf_dummy_interface, effective_default_mtu
+            )
 
             # Check for interface-specific netplan_parameters custom field
-            if (
-                hasattr(vrf_dummy_interface, "custom_fields")
-                and vrf_dummy_interface.custom_fields
-            ):
-                interface_netplan_params = vrf_dummy_interface.custom_fields.get(
-                    "netplan_parameters"
-                )
-                if interface_netplan_params and isinstance(
-                    interface_netplan_params, dict
-                ):
-                    dummy_config.update(interface_netplan_params)
+            dummy_params = self._get_netplan_parameters(vrf_dummy_interface)
+            if dummy_params:
+                self._apply_netplan_overrides(dummy_config, dummy_params)
 
             if dummy_config:
                 network_dummy_devices[vrf_dummy_name] = dummy_config
@@ -708,20 +721,13 @@ class NetplanExtractor(BaseExtractor):
                 )
 
             # Process VRF assignment
-            if vrf_dummy_interface.id in interface_vrf_assignments:
-                vrf_name, vrf_table = interface_vrf_assignments[vrf_dummy_interface.id]
-                # Initialize VRF entry if not exists
-                if vrf_name not in network_vrfs:
-                    network_vrfs[vrf_name] = {
-                        "table": vrf_table,
-                        "interfaces": [],
-                    }
-                # Add dummy interface to VRF's interface list
-                if vrf_dummy_name not in network_vrfs[vrf_name]["interfaces"]:
-                    network_vrfs[vrf_name]["interfaces"].append(vrf_dummy_name)
-                    logger.debug(
-                        f"Added VRF dummy interface {vrf_dummy_name} to VRF {vrf_name} (table {vrf_table}) for device {device.name}"
-                    )
+            self._register_vrf_membership(
+                vrf_dummy_interface.id,
+                vrf_dummy_name,
+                interface_vrf_assignments,
+                network_vrfs,
+                device.name,
+            )
 
         # Process LAG / bond / port channel interfaces now that all members are
         # known. The default parameters configure an LACP (802.3ad) port channel;
@@ -734,8 +740,20 @@ class NetplanExtractor(BaseExtractor):
             if not bond_name:
                 continue
 
+            members = bond_members.get(lag_id, [])
+            if not members:
+                # A managed LAG whose members are all ineligible (untagged,
+                # disabled, mgmt_only or missing MAC/label) would otherwise emit
+                # an empty "interfaces" list, which is invalid netplan. Skip the
+                # bond with a warning rather than emitting a broken entry.
+                logger.warning(
+                    f"Skipping bond {bond_name} on device {device.name}: "
+                    f"no eligible member interfaces"
+                )
+                continue
+
             bond_config = {
-                "interfaces": bond_members.get(lag_id, []),
+                "interfaces": members,
                 "parameters": {
                     "mode": "802.3ad",
                     "lacp-rate": "fast",
@@ -745,37 +763,27 @@ class NetplanExtractor(BaseExtractor):
             }
 
             # Add MTU - use interface MTU if set, otherwise use effective default
-            if hasattr(lag_interface, "mtu") and lag_interface.mtu:
-                bond_config["mtu"] = lag_interface.mtu
-            else:
-                bond_config["mtu"] = effective_default_mtu
+            bond_config["mtu"] = self._resolve_mtu(lag_interface, effective_default_mtu)
 
             # IP addresses are assigned to the LAG interface itself
-            addresses = []
-            try:
-                ip_addresses = self.bulk_loader.get_interface_ip_addresses(
-                    lag_interface
-                )
-                for ip in ip_addresses:
-                    if ip.address:
-                        addresses.append(ip.address)
-            except Exception:
-                pass
-
+            addresses = self._collect_addresses(lag_interface)
             if addresses:
                 bond_config["addresses"] = addresses
 
             # Per-LAG override via the netplan_parameters custom field. A shallow
             # update mirrors the behaviour for other interface types: providing a
             # "parameters" dict replaces the auto-generated defaults entirely (so
-            # e.g. an active-backup bond does not keep LACP-only options).
-            if (
-                hasattr(lag_interface, "custom_fields")
-                and lag_interface.custom_fields
-            ):
-                lag_params = lag_interface.custom_fields.get("netplan_parameters")
-                if lag_params and isinstance(lag_params, dict):
-                    bond_config.update(lag_params)
+            # e.g. an active-backup bond does not keep LACP-only options). The
+            # auto-detected membership is authoritative, so an "interfaces"
+            # override is rejected.
+            lag_params = self._get_netplan_parameters(lag_interface)
+            if lag_params:
+                self._apply_netplan_overrides(
+                    bond_config,
+                    lag_params,
+                    protected=frozenset({"interfaces"}),
+                    context=f"bond {bond_name} on device {device.name}",
+                )
 
             network_bonds[bond_name] = bond_config
             logger.debug(
@@ -784,19 +792,13 @@ class NetplanExtractor(BaseExtractor):
             )
 
             # Process VRF assignment for the LAG interface if present
-            if lag_id in interface_vrf_assignments:
-                vrf_name, vrf_table = interface_vrf_assignments[lag_id]
-                if vrf_name not in network_vrfs:
-                    network_vrfs[vrf_name] = {
-                        "table": vrf_table,
-                        "interfaces": [],
-                    }
-                if bond_name not in network_vrfs[vrf_name]["interfaces"]:
-                    network_vrfs[vrf_name]["interfaces"].append(bond_name)
-                    logger.debug(
-                        f"Added bond {bond_name} to VRF {vrf_name} "
-                        f"(table {vrf_table}) for device {device.name}"
-                    )
+            self._register_vrf_membership(
+                lag_id,
+                bond_name,
+                interface_vrf_assignments,
+                network_vrfs,
+                device.name,
+            )
 
         # Add metalbox dummy device if in metalbox mode and device has metalbox role
         reconciler_mode = kwargs.get("reconciler_mode", "manager")

--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -95,6 +95,13 @@ class NetplanExtractor(BaseExtractor):
         - Must have "managed-by-osism" tag
         - If assigned to a VRF, the interface is added to the VRF's interface list
 
+        For LAG / bond / port channel interfaces (type=lag):
+        - Must have "managed-by-osism" tag
+        - Generates a network_bonds entry; member interfaces (those whose "lag"
+          field points at the LAG) are renamed via their MAC but carry no IPs
+        - Defaults to an LACP (802.3ad) bond; override the parameters per LAG via
+          the netplan_parameters custom field (e.g. to switch to active-backup)
+
         If device.config_context contains a "netplan_parameters" key, its values
         are deep-merged into the auto-generated parameters. Since config_context
         includes all Config Context sources (segments, regions, sites, roles, tags)
@@ -141,6 +148,7 @@ class NetplanExtractor(BaseExtractor):
         network_vlans = {}
         network_vrfs = {}
         network_tunnels = {}
+        network_bonds = {}
         loopback0_interface = None
 
         # Track VXLAN interfaces for later processing (need loopback0 IP first)
@@ -154,6 +162,25 @@ class NetplanExtractor(BaseExtractor):
         # Track VRF assignments during interface processing
         # Format: {interface_id: (vrf_name, vrf_table)}
         interface_vrf_assignments = {}
+
+        # Track LAG / bond / port channel members per LAG interface id
+        # Format: {lag_interface_id: [member_label, ...]}
+        bond_members = {}
+
+        # Identify LAG (bond / port channel) interfaces up front so that member
+        # interfaces can be linked to them regardless of interface ordering. A LAG
+        # is modelled as a NetBox interface of type "lag" carrying the
+        # managed-by-osism tag - the same NetBox modelling that SONiC port channel
+        # detection relies on.
+        lag_interfaces_by_id = {}
+        for interface in interfaces:
+            if (
+                interface.type
+                and interface.type.value == "lag"
+                and getattr(interface, "tags", None)
+                and "managed-by-osism" in [tag.slug for tag in interface.tags]
+            ):
+                lag_interfaces_by_id[interface.id] = interface
 
         for interface in interfaces:
             # Check if interface has managed-by-osism tag
@@ -268,6 +295,11 @@ class NetplanExtractor(BaseExtractor):
                         logger.debug(
                             f"Added VXLAN interface {interface_name} to VRF {vrf_name} (table {vrf_table}) for device {device.name}"
                         )
+                continue
+
+            # LAG / bond / port channel interfaces are processed after the main
+            # loop (members may appear before or after the LAG interface itself).
+            if interface.id in lag_interfaces_by_id:
                 continue
 
             # Check if this is a virtual interface (VLAN or VRF dummy)
@@ -404,6 +436,25 @@ class NetplanExtractor(BaseExtractor):
                 interface_config["mtu"] = interface.mtu
             else:
                 interface_config["mtu"] = effective_default_mtu
+
+            # Bond / port channel members only need the MAC-based rename and the
+            # MTU here. The bond interface itself carries the IP configuration, so
+            # members must not get addresses, DHCP or leaf link-local settings.
+            lag_parent_id = (
+                interface.lag.id if getattr(interface, "lag", None) else None
+            )
+            if lag_parent_id is not None and lag_parent_id in lag_interfaces_by_id:
+                if hasattr(interface, "custom_fields") and interface.custom_fields:
+                    member_params = interface.custom_fields.get("netplan_parameters")
+                    if member_params and isinstance(member_params, dict):
+                        interface_config.update(member_params)
+                network_ethernets[label] = interface_config
+                bond_members.setdefault(lag_parent_id, []).append(label)
+                logger.debug(
+                    f"Interface {label} is a member of LAG "
+                    f"{lag_interfaces_by_id[lag_parent_id].name} on device {device.name}"
+                )
+                continue
 
             # Get IP addresses for this interface
             addresses = []
@@ -672,6 +723,81 @@ class NetplanExtractor(BaseExtractor):
                         f"Added VRF dummy interface {vrf_dummy_name} to VRF {vrf_name} (table {vrf_table}) for device {device.name}"
                     )
 
+        # Process LAG / bond / port channel interfaces now that all members are
+        # known. The default parameters configure an LACP (802.3ad) port channel;
+        # they can be overridden per LAG via the netplan_parameters custom field on
+        # the LAG interface (e.g. to switch to active-backup).
+        for lag_id, lag_interface in lag_interfaces_by_id.items():
+            bond_name = (
+                lag_interface.label if lag_interface.label else lag_interface.name
+            )
+            if not bond_name:
+                continue
+
+            bond_config = {
+                "interfaces": bond_members.get(lag_id, []),
+                "parameters": {
+                    "mode": "802.3ad",
+                    "lacp-rate": "fast",
+                    "mii-monitor-interval": 100,
+                    "transmit-hash-policy": "layer3+4",
+                },
+            }
+
+            # Add MTU - use interface MTU if set, otherwise use effective default
+            if hasattr(lag_interface, "mtu") and lag_interface.mtu:
+                bond_config["mtu"] = lag_interface.mtu
+            else:
+                bond_config["mtu"] = effective_default_mtu
+
+            # IP addresses are assigned to the LAG interface itself
+            addresses = []
+            try:
+                ip_addresses = self.bulk_loader.get_interface_ip_addresses(
+                    lag_interface
+                )
+                for ip in ip_addresses:
+                    if ip.address:
+                        addresses.append(ip.address)
+            except Exception:
+                pass
+
+            if addresses:
+                bond_config["addresses"] = addresses
+
+            # Per-LAG override via the netplan_parameters custom field. A shallow
+            # update mirrors the behaviour for other interface types: providing a
+            # "parameters" dict replaces the auto-generated defaults entirely (so
+            # e.g. an active-backup bond does not keep LACP-only options).
+            if (
+                hasattr(lag_interface, "custom_fields")
+                and lag_interface.custom_fields
+            ):
+                lag_params = lag_interface.custom_fields.get("netplan_parameters")
+                if lag_params and isinstance(lag_params, dict):
+                    bond_config.update(lag_params)
+
+            network_bonds[bond_name] = bond_config
+            logger.debug(
+                f"Added bond {bond_name} with members "
+                f"{bond_config['interfaces']} for device {device.name}"
+            )
+
+            # Process VRF assignment for the LAG interface if present
+            if lag_id in interface_vrf_assignments:
+                vrf_name, vrf_table = interface_vrf_assignments[lag_id]
+                if vrf_name not in network_vrfs:
+                    network_vrfs[vrf_name] = {
+                        "table": vrf_table,
+                        "interfaces": [],
+                    }
+                if bond_name not in network_vrfs[vrf_name]["interfaces"]:
+                    network_vrfs[vrf_name]["interfaces"].append(bond_name)
+                    logger.debug(
+                        f"Added bond {bond_name} to VRF {vrf_name} "
+                        f"(table {vrf_table}) for device {device.name}"
+                    )
+
         # Add metalbox dummy device if in metalbox mode and device has metalbox role
         reconciler_mode = kwargs.get("reconciler_mode", "manager")
         if reconciler_mode == "metalbox" and hasattr(device, "role") and device.role:
@@ -688,6 +814,7 @@ class NetplanExtractor(BaseExtractor):
             and not network_dummy_devices
             and not network_vlans
             and not network_tunnels
+            and not network_bonds
         ):
             return None
 
@@ -700,6 +827,8 @@ class NetplanExtractor(BaseExtractor):
             result["network_vlans"] = network_vlans
         if network_tunnels:
             result["network_tunnels"] = network_tunnels
+        if network_bonds:
+            result["network_bonds"] = network_bonds
         if network_vrfs:
             result["network_vrfs"] = network_vrfs
 

--- a/tests/unit/netbox/test_netplan_extractor.py
+++ b/tests/unit/netbox/test_netplan_extractor.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the LAG / bond (port channel) handling in NetplanExtractor.
+
+The extractor reads device interfaces through a ``BulkDataLoader`` and writes
+the generated parameters back through a ``NetBoxClient``. Both collaborators are
+replaced by thin stubs here; only the attributes the extractor actually reads
+off interface / IP objects are modelled (mirroring the SONiC NetBox modelling:
+a LAG is an interface of ``type == "lag"`` and members carry a ``lag`` back-ref).
+"""
+
+from types import SimpleNamespace
+
+from extractors.netplan_extractor import NetplanExtractor
+
+
+def _tag(slug="managed-by-osism"):
+    return SimpleNamespace(slug=slug)
+
+
+def _iface(
+    id,
+    name,
+    *,
+    label=None,
+    type_value="1000base-t",
+    mac=None,
+    mtu=None,
+    lag=None,
+    tags=("managed-by-osism",),
+    custom_fields=None,
+):
+    """Build a NetBox-interface-shaped stub with the attributes the extractor reads."""
+    return SimpleNamespace(
+        id=id,
+        name=name,
+        label=label if label is not None else name,
+        type=SimpleNamespace(value=type_value),
+        mac_address=mac,
+        mtu=mtu,
+        enabled=True,
+        mgmt_only=False,
+        vrf=None,
+        untagged_vlan=None,
+        parent=None,
+        connected_endpoints=None,
+        lag=lag,
+        tags=[_tag(t) for t in tags],
+        custom_fields=custom_fields if custom_fields is not None else {},
+    )
+
+
+class _FakeBulkLoader:
+    def __init__(self, interfaces, ips=None):
+        self._interfaces = interfaces
+        self._ips = ips or {}
+
+    def get_device_interfaces(self, device):
+        return self._interfaces
+
+    def get_interface_ip_addresses(self, interface):
+        return self._ips.get(interface.id, [])
+
+
+class _FakeNetBoxClient:
+    def __init__(self):
+        self.written = []
+
+    def update_device_custom_field(self, device, field, value):
+        self.written.append((field, value))
+        return True
+
+
+def _device():
+    return SimpleNamespace(
+        id=1, name="server1", config_context={}, role=None, custom_fields={}
+    )
+
+
+def _extract(interfaces, ips=None):
+    bulk = _FakeBulkLoader(interfaces, ips)
+    client = _FakeNetBoxClient()
+    extractor = NetplanExtractor(api=object(), netbox_client=client, bulk_loader=bulk)
+    return extractor.extract(_device())
+
+
+class TestBondGeneration:
+    def test_lacp_bond_is_generated_from_lag_and_members(self):
+        lag = _iface(10, "bond0", type_value="lag", mac=None, mtu=9000)
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+        m2 = _iface(
+            2,
+            "eno8403",
+            mac="AA:BB:CC:00:00:02",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+        ips = {10: [SimpleNamespace(address="10.0.0.5/24")]}
+
+        result = _extract([lag, m1, m2], ips)
+
+        # Bond carries the LACP defaults, MTU and the IP of the LAG interface.
+        assert result["network_bonds"]["bond0"] == {
+            "interfaces": ["eno8303", "eno8403"],
+            "parameters": {
+                "mode": "802.3ad",
+                "lacp-rate": "fast",
+                "mii-monitor-interval": 100,
+                "transmit-hash-policy": "layer3+4",
+            },
+            "mtu": 9000,
+            "addresses": ["10.0.0.5/24"],
+        }
+
+        # Members are renamed via their MAC but must not carry any IPs/DHCP.
+        assert result["network_ethernets"]["eno8303"] == {
+            "match": {"macaddress": "aa:bb:cc:00:00:01"},
+            "set-name": "eno8303",
+            "mtu": 9000,
+        }
+        assert "addresses" not in result["network_ethernets"]["eno8403"]
+        assert "dhcp4" not in result["network_ethernets"]["eno8403"]
+
+    def test_custom_field_overrides_parameters_for_active_backup(self):
+        active_backup = {
+            "parameters": {
+                "mode": "active-backup",
+                "primary": "eno8303",
+                "mii-monitor-interval": 100,
+                "fail-over-mac-policy": "active",
+            }
+        }
+        lag = _iface(
+            10,
+            "bond0",
+            type_value="lag",
+            mtu=9000,
+            custom_fields={"netplan_parameters": active_backup},
+        )
+        m1 = _iface(
+            1, "eno8303", mac="AA:BB:CC:00:00:01", lag=SimpleNamespace(id=10, name="bond0")
+        )
+        m2 = _iface(
+            2, "eno8403", mac="AA:BB:CC:00:00:02", lag=SimpleNamespace(id=10, name="bond0")
+        )
+
+        result = _extract([lag, m1, m2])
+
+        # The explicit parameters fully replace the LACP defaults.
+        assert result["network_bonds"]["bond0"]["parameters"] == active_backup[
+            "parameters"
+        ]
+        assert result["network_bonds"]["bond0"]["interfaces"] == ["eno8303", "eno8403"]
+
+    def test_member_of_unmanaged_lag_falls_back_to_regular_ethernet(self):
+        # LAG parent without the managed-by-osism tag -> not treated as a bond.
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=99, name="bond9"),
+        )
+        ips = {1: [SimpleNamespace(address="10.0.0.5/24")]}
+
+        result = _extract([m1], ips)
+
+        assert "network_bonds" not in result
+        # As a plain ethernet it keeps its own addresses.
+        assert result["network_ethernets"]["eno8303"]["addresses"] == ["10.0.0.5/24"]

--- a/tests/unit/netbox/test_netplan_extractor.py
+++ b/tests/unit/netbox/test_netplan_extractor.py
@@ -18,6 +18,11 @@ def _tag(slug="managed-by-osism"):
     return SimpleNamespace(slug=slug)
 
 
+def _vrf(name="vrf42"):
+    """Build a NetBox-VRF-shaped stub; table id is parsed from the name (vrfN)."""
+    return SimpleNamespace(name=name, rd=None)
+
+
 def _iface(
     id,
     name,
@@ -27,6 +32,9 @@ def _iface(
     mac=None,
     mtu=None,
     lag=None,
+    enabled=True,
+    mgmt_only=False,
+    vrf=None,
     tags=("managed-by-osism",),
     custom_fields=None,
 ):
@@ -38,9 +46,9 @@ def _iface(
         type=SimpleNamespace(value=type_value),
         mac_address=mac,
         mtu=mtu,
-        enabled=True,
-        mgmt_only=False,
-        vrf=None,
+        enabled=enabled,
+        mgmt_only=mgmt_only,
+        vrf=vrf,
         untagged_vlan=None,
         parent=None,
         connected_endpoints=None,
@@ -144,18 +152,25 @@ class TestBondGeneration:
             custom_fields={"netplan_parameters": active_backup},
         )
         m1 = _iface(
-            1, "eno8303", mac="AA:BB:CC:00:00:01", lag=SimpleNamespace(id=10, name="bond0")
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            lag=SimpleNamespace(id=10, name="bond0"),
         )
         m2 = _iface(
-            2, "eno8403", mac="AA:BB:CC:00:00:02", lag=SimpleNamespace(id=10, name="bond0")
+            2,
+            "eno8403",
+            mac="AA:BB:CC:00:00:02",
+            lag=SimpleNamespace(id=10, name="bond0"),
         )
 
         result = _extract([lag, m1, m2])
 
         # The explicit parameters fully replace the LACP defaults.
-        assert result["network_bonds"]["bond0"]["parameters"] == active_backup[
-            "parameters"
-        ]
+        assert (
+            result["network_bonds"]["bond0"]["parameters"]
+            == active_backup["parameters"]
+        )
         assert result["network_bonds"]["bond0"]["interfaces"] == ["eno8303", "eno8403"]
 
     def test_member_of_unmanaged_lag_falls_back_to_regular_ethernet(self):
@@ -174,3 +189,190 @@ class TestBondGeneration:
         assert "network_bonds" not in result
         # As a plain ethernet it keeps its own addresses.
         assert result["network_ethernets"]["eno8303"]["addresses"] == ["10.0.0.5/24"]
+
+
+class TestBondEligibilityGates:
+    """Edge cases for the LAG / member eligibility gates (review findings 1-3)."""
+
+    def test_mgmt_only_lag_is_not_emitted_as_a_bond(self):
+        # Finding 1: a mgmt_only LAG must not become an active bond.
+        lag = _iface(10, "bond0", type_value="lag", mtu=9000, mgmt_only=True)
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m1])
+
+        assert result is None or "network_bonds" not in result
+
+    def test_disabled_lag_is_not_emitted_as_a_bond(self):
+        # Finding 1: a disabled LAG must not become an active bond, and must not
+        # leak into network_ethernets as an activation-mode: off entry.
+        lag = _iface(
+            10,
+            "bond0",
+            type_value="lag",
+            mac="AA:BB:CC:00:00:99",
+            mtu=9000,
+            enabled=False,
+        )
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m1])
+
+        assert result is None or "network_bonds" not in result
+        if result:
+            assert "bond0" not in result.get("network_ethernets", {})
+
+    def test_disabled_member_is_dropped_not_orphaned(self):
+        # Finding 2: a disabled member of a 2-member bond is excluded from the
+        # bond's interfaces AND must not be emitted as a dangling ethernet.
+        lag = _iface(10, "bond0", type_value="lag", mtu=9000)
+        m_up = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+        m_down = _iface(
+            2,
+            "eno8403",
+            mac="AA:BB:CC:00:00:02",
+            mtu=9000,
+            enabled=False,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m_up, m_down])
+
+        assert result["network_bonds"]["bond0"]["interfaces"] == ["eno8303"]
+        # The disabled member is neither in the bond nor a standalone ethernet.
+        assert "eno8403" not in result["network_ethernets"]
+
+    def test_bond_with_no_eligible_members_is_skipped(self):
+        # Finding 3: a managed LAG whose members are all ineligible must not emit
+        # an empty interfaces list (invalid netplan) - the bond is skipped.
+        lag = _iface(10, "bond0", type_value="lag", mtu=9000)
+        # Member without the managed-by-osism tag -> not collected as a member.
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            tags=(),
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m1])
+
+        assert result is None or "network_bonds" not in result
+
+
+class TestBondCustomFieldOverrides:
+    """Custom-field override edge cases (review findings 4 and 7)."""
+
+    def test_member_custom_field_cannot_reintroduce_l3_or_clobber_identity(self):
+        # Finding 4: a member's netplan_parameters must not reintroduce
+        # addresses/dhcp or overwrite the MAC-rename identity (match/set-name).
+        member_cf = {
+            "netplan_parameters": {
+                "addresses": ["10.9.9.9/24"],
+                "dhcp4": True,
+                "match": {"macaddress": "ff:ff:ff:ff:ff:ff"},
+                "set-name": "hijacked",
+                "wakeonlan": True,  # a harmless key that should pass through
+            }
+        }
+        lag = _iface(10, "bond0", type_value="lag", mtu=9000)
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+            custom_fields=member_cf,
+        )
+
+        result = _extract([lag, m1])
+
+        eth = result["network_ethernets"]["eno8303"]
+        assert eth["match"] == {"macaddress": "aa:bb:cc:00:00:01"}
+        assert eth["set-name"] == "eno8303"
+        assert "addresses" not in eth
+        assert "dhcp4" not in eth
+        # The non-conflicting key is still applied.
+        assert eth["wakeonlan"] is True
+
+    def test_lag_custom_field_cannot_override_auto_detected_members(self):
+        # Finding 7: the auto-detected membership is authoritative; an
+        # "interfaces" key in the LAG custom field is ignored.
+        lag = _iface(
+            10,
+            "bond0",
+            type_value="lag",
+            mtu=9000,
+            custom_fields={"netplan_parameters": {"interfaces": ["wrong0"]}},
+        )
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m1])
+
+        assert result["network_bonds"]["bond0"]["interfaces"] == ["eno8303"]
+
+
+class TestBondVrfMembership:
+    """VRF-on-bond vs VRF-on-member (review finding 8)."""
+
+    def test_vrf_assignment_on_lag_adds_the_bond_to_the_vrf(self):
+        lag = _iface(10, "bond0", type_value="lag", mtu=9000, vrf=_vrf("vrf42"))
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m1])
+
+        assert result["network_vrfs"]["vrf42"]["table"] == 42
+        assert result["network_vrfs"]["vrf42"]["interfaces"] == ["bond0"]
+
+    def test_vrf_assignment_on_member_is_not_registered(self):
+        # The bond carries L3 config, not its members: a VRF on a member must
+        # not create a VRF interface entry.
+        lag = _iface(10, "bond0", type_value="lag", mtu=9000)
+        m1 = _iface(
+            1,
+            "eno8303",
+            mac="AA:BB:CC:00:00:01",
+            mtu=9000,
+            vrf=_vrf("vrf42"),
+            lag=SimpleNamespace(id=10, name="bond0"),
+        )
+
+        result = _extract([lag, m1])
+
+        # The member must not appear in any VRF, and no VRF is created for it.
+        assert "network_vrfs" not in result or "eno8303" not in [
+            iface
+            for vrf in result["network_vrfs"].values()
+            for iface in vrf["interfaces"]
+        ]


### PR DESCRIPTION
## Summary

Auto-generate a `network_bonds` section in the Netplan parameters when a device has a **port channel / LAG configured in NetBox**. This mirrors the NetBox modelling that SONiC port channel detection relies on (`osism/python-osism`, `detect_port_channels()`): a LAG is an interface of `type == "lag"` and member interfaces carry a `lag` back-reference to it. Only the **host side** is handled here — the SONiC counterpart is unaffected.

## Behaviour

- **LAG interface** (`type=lag`, `managed-by-osism` tag) → `network_bonds` entry. The bond carries the IP addresses and MTU of the LAG interface itself.
- **Member interfaces** (their `lag` field points at a managed LAG) are still rendered as `network_ethernets` entries (MAC `match` + `set-name`), but **without** addresses, DHCP or leaf link-local settings — the bond holds the IP configuration.
- **Default = LACP (802.3ad)**: `lacp-rate: fast`, `mii-monitor-interval: 100`, `transmit-hash-policy: layer3+4`.
- **Per-LAG override** via the `netplan_parameters` custom field on the LAG interface (shallow update, consistent with other interface types). Providing a `parameters` dict replaces the auto-generated defaults entirely — e.g. the `active-backup` case from the issue.
- VRF assignment of the LAG interface is reflected in `network_vrfs`.

The output key `network_bonds` is already rendered to `network.bonds:` by the consuming role template in `osism/ansible-collection-commons` (`roles/network/templates/netplan/01-osism.yaml.j2`), so no change on the consumer side is needed.

### Example output (auto-generated, LACP default)

```yaml
network_ethernets:
  eno8303: {match: {macaddress: "aa:bb:cc:00:00:01"}, set-name: eno8303, mtu: 9100}
  eno8403: {match: {macaddress: "aa:bb:cc:00:00:02"}, set-name: eno8403, mtu: 9100}
network_bonds:
  bond0:
    interfaces: [eno8303, eno8403]
    parameters: {mode: 802.3ad, lacp-rate: fast, mii-monitor-interval: 100, transmit-hash-policy: layer3+4}
    mtu: 9100
    addresses: [10.0.0.5/24]
```

### active-backup case (issue example) — set on the LAG interface's `netplan_parameters` custom field

```json
{"parameters": {"mode": "active-backup", "primary": "eno8303", "mii-monitor-interval": 100, "fail-over-mac-policy": "active"}}
```

## Tests

New `tests/unit/netbox/test_netplan_extractor.py` covering the LACP default, the active-backup custom-field override, and the fallback when the LAG parent is not managed. Full unit suite passes (176 tests).

Closes osism/issues#1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)