### PR TITLE
Add tier 3 unit tests: primary_ip, config_context, custom_field, secrets, gnmic

### DIFF
--- a/tests/unit/netbox/conftest.py
+++ b/tests/unit/netbox/conftest.py
@@ -12,6 +12,11 @@ Provides:
   stand-ins for the pynetbox device and tag objects exercised by the tier-2
   modules (filters, device_mapping, parallel_processor). The factories
   intentionally model only the attributes those modules read.
+* ``make_ip`` / ``make_interface`` / ``make_fake_api`` -- factories for the
+  IP-address, interface and pynetbox-session shapes used by the tier-3
+  extractors (primary_ip and gnmic). ``make_interface`` / ``make_fake_api``
+  model the ``dcim.interfaces.filter`` / ``ipam.ip_addresses.filter`` lookups
+  performed by ``gnmic_extractor`` and are reused by tiers 4-9.
 """
 
 from types import SimpleNamespace
@@ -48,4 +53,46 @@ def make_device(id, name, *, role=None, site=None, tags=(), custom_fields=None):
         site=site,
         tags=[make_tag(t) for t in tags],
         custom_fields=custom_fields if custom_fields is not None else {},
+    )
+
+
+def make_ip(address):
+    """Build a NetBox-shaped IP-address stub with the ``.address`` attribute."""
+    return SimpleNamespace(address=address)
+
+
+def make_interface(*, id, mgmt_only, tags=()):
+    """Build a NetBox-shaped interface stub.
+
+    Models only the attributes ``gnmic_extractor`` reads off an interface:
+    ``id``, ``mgmt_only`` and ``tags`` (list of tag stubs).
+    """
+    return SimpleNamespace(
+        id=id,
+        mgmt_only=mgmt_only,
+        tags=[make_tag(t) for t in tags],
+    )
+
+
+def make_fake_api(interfaces=(), ips_by_interface=None):
+    """Build a pynetbox-shaped API session stub.
+
+    Exposes ``dcim.interfaces.filter(device_id=...)`` returning ``interfaces``
+    and ``ipam.ip_addresses.filter(interface_id=...)`` returning the addresses
+    registered for that interface id in ``ips_by_interface`` (default empty).
+    """
+    ips_by_interface = ips_by_interface or {}
+    return SimpleNamespace(
+        dcim=SimpleNamespace(
+            interfaces=SimpleNamespace(
+                filter=lambda device_id: list(interfaces),
+            ),
+        ),
+        ipam=SimpleNamespace(
+            ip_addresses=SimpleNamespace(
+                filter=lambda interface_id: list(
+                    ips_by_interface.get(interface_id, [])
+                ),
+            ),
+        ),
     )

--- a/tests/unit/netbox/test_base_extractor.py
+++ b/tests/unit/netbox/test_base_extractor.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for files/netbox/extractors/base_extractor.py.
+
+Analogous to the exceptions.py inheritance smoke tests: ``BaseExtractor`` is an
+abstract base class, and every tier-3 extractor must subclass it and provide a
+concrete ``extract`` (so instances are creatable).
+"""
+
+import pytest
+
+from extractors.base_extractor import BaseExtractor
+from extractors.config_context_extractor import ConfigContextExtractor
+from extractors.custom_field_extractor import CustomFieldExtractor
+from extractors.gnmic_extractor import GnmicExtractor
+from extractors.primary_ip_extractor import PrimaryIPExtractor
+from extractors.secrets_extractor import SecretsExtractor
+
+TIER3_EXTRACTORS = [
+    ConfigContextExtractor,
+    CustomFieldExtractor,
+    GnmicExtractor,
+    PrimaryIPExtractor,
+    SecretsExtractor,
+]
+
+
+def test_base_extractor_cannot_be_instantiated():
+    # The abstractmethod on extract prevents direct instantiation.
+    with pytest.raises(TypeError):
+        BaseExtractor()
+
+
+@pytest.mark.parametrize("extractor_cls", TIER3_EXTRACTORS)
+def test_tier3_extractor_is_concrete_subclass(extractor_cls):
+    assert issubclass(extractor_cls, BaseExtractor)
+    # A concrete extract overrides the abstractmethod, so instances are creatable.
+    assert isinstance(extractor_cls(), BaseExtractor)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_config_context_extractor.py
+++ b/tests/unit/netbox/test_config_context_extractor.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/extractors/config_context_extractor.py.
+
+The extractor copies ``device.config_context`` into a new dict, dropping the
+``frr_parameters`` / ``netplan_parameters`` keys (handled by their dedicated
+extractors) and the empty-string key. Non-dict values pass straight through.
+"""
+
+import pytest
+
+from extractors.config_context_extractor import ConfigContextExtractor
+
+from .conftest import make_device
+
+
+def _device(ctx):
+    """Build a device exposing the ``config_context`` attribute."""
+    device = make_device(1, "node1")
+    device.config_context = ctx
+    return device
+
+
+class TestExtract:
+    def test_strips_frr_and_netplan_keeps_rest(self):
+        ctx = {
+            "frr_parameters": {"frr_local_as": 1},
+            "netplan_parameters": {"network_ethernets": {}},
+            "ntp_servers": ["a", "b"],
+            "foo": 1,
+        }
+        result = ConfigContextExtractor().extract(_device(ctx))
+        assert result == {"ntp_servers": ["a", "b"], "foo": 1}
+
+    def test_strips_empty_string_key(self):
+        ctx = {"": "junk", "keep": 1}
+        assert ConfigContextExtractor().extract(_device(ctx)) == {"keep": 1}
+
+    def test_unfiltered_dict_is_copied_not_mutated(self):
+        ctx = {"a": 1, "b": 2}
+        result = ConfigContextExtractor().extract(_device(ctx))
+        assert result == {"a": 1, "b": 2}
+        # The comprehension returns a new dict; the original is left untouched.
+        assert result is not ctx
+        assert ctx == {"a": 1, "b": 2}
+
+    def test_only_filtered_keys_returns_empty_dict(self):
+        ctx = {"frr_parameters": 1, "netplan_parameters": 2, "": 3}
+        assert ConfigContextExtractor().extract(_device(ctx)) == {}
+
+    @pytest.mark.parametrize("ctx", [None, ["a", "b"], "a string"])
+    def test_non_dict_passed_through_unchanged(self, ctx):
+        assert ConfigContextExtractor().extract(_device(ctx)) is ctx
+
+    def test_empty_dict_returns_empty_dict(self):
+        assert ConfigContextExtractor().extract(_device({})) == {}
+
+    def test_extra_kwargs_are_ignored(self):
+        ctx = {"keep": 1, "frr_parameters": 2}
+        assert ConfigContextExtractor().extract(_device(ctx), unused="x") == {"keep": 1}
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_custom_field_extractor.py
+++ b/tests/unit/netbox/test_custom_field_extractor.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/extractors/custom_field_extractor.py.
+
+The extractor requires a ``field_name`` and returns ``device.custom_fields``
+(coerced to ``{}`` when falsy) looked up by that name, or ``None`` on a miss.
+"""
+
+import pytest
+
+from extractors.custom_field_extractor import CustomFieldExtractor
+
+from .conftest import make_device
+
+
+class TestExtract:
+    def test_field_name_omitted_raises(self):
+        device = make_device(1, "node1", custom_fields={"a": 1})
+        with pytest.raises(ValueError, match="field_name parameter is required"):
+            CustomFieldExtractor().extract(device)
+
+    @pytest.mark.parametrize("field_name", [None, ""])
+    def test_falsy_field_name_raises(self, field_name):
+        device = make_device(1, "node1", custom_fields={"a": 1})
+        with pytest.raises(ValueError, match="field_name parameter is required"):
+            CustomFieldExtractor().extract(device, field_name=field_name)
+
+    @pytest.mark.parametrize("value", [0, False, "", "value", 42])
+    def test_present_field_returns_value_including_falsy(self, value):
+        device = make_device(1, "node1", custom_fields={"target": value})
+        assert CustomFieldExtractor().extract(device, field_name="target") == value
+
+    def test_absent_field_returns_none(self):
+        device = make_device(1, "node1", custom_fields={"other": 1})
+        assert CustomFieldExtractor().extract(device, field_name="target") is None
+
+    def test_none_custom_fields_coerced_to_empty(self):
+        device = make_device(1, "node1", custom_fields=None)
+        assert CustomFieldExtractor().extract(device, field_name="target") is None
+
+    def test_empty_custom_fields_returns_none(self):
+        device = make_device(1, "node1", custom_fields={})
+        assert CustomFieldExtractor().extract(device, field_name="target") is None
+
+    def test_nested_value_returned_by_reference(self):
+        nested = {"a": [1, 2], "b": {"c": 3}}
+        device = make_device(1, "node1", custom_fields={"target": nested})
+        result = CustomFieldExtractor().extract(device, field_name="target")
+        assert result is nested
+
+    def test_extra_kwargs_are_ignored(self):
+        device = make_device(1, "node1", custom_fields={"target": "v"})
+        result = CustomFieldExtractor().extract(device, field_name="target", unused="x")
+        assert result == "v"
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_gnmic_extractor.py
+++ b/tests/unit/netbox/test_gnmic_extractor.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/extractors/gnmic_extractor.py.
+
+The extractor builds a gnmic target config for switches tagged
+``managed-by-metalbox``. It reads interfaces / IP addresses through a pynetbox
+session, faked here by ``make_fake_api`` (plain lists) or, where call arguments
+matter, by ``MagicMock`` filters. The module-level ``loguru`` logger is patched
+with a ``MagicMock`` via ``monkeypatch`` (restored after each test) only where a
+log assertion documents the branch taken.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from extractors.gnmic_extractor import GnmicExtractor
+
+from .conftest import make_device, make_fake_api, make_interface, make_ip
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("extractors.gnmic_extractor.logger", logger)
+    return logger
+
+
+def _oob_interface(id=10):
+    """A managed OOB interface: mgmt_only with the managed-by-osism tag."""
+    return make_interface(id=id, mgmt_only=True, tags=("managed-by-osism",))
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_defaults(self):
+        extractor = GnmicExtractor()
+        assert extractor.api is None
+        assert extractor.netbox_client is None
+
+    def test_custom_values_are_stored(self):
+        api = object()
+        client = object()
+        extractor = GnmicExtractor(api=api, netbox_client=client)
+        assert extractor.api is api
+        assert extractor.netbox_client is client
+
+
+# ---------------------------------------------------------------------------
+# _has_metalbox_tag
+# ---------------------------------------------------------------------------
+
+
+class TestHasMetalboxTag:
+    def test_no_tags_attribute_returns_false(self):
+        device = SimpleNamespace(name="d1")  # no .tags attribute at all
+        assert GnmicExtractor()._has_metalbox_tag(device) is False
+
+    def test_empty_tags_returns_false(self):
+        device = make_device(1, "d1", tags=())
+        assert GnmicExtractor()._has_metalbox_tag(device) is False
+
+    def test_tags_without_metalbox_returns_false(self):
+        device = make_device(1, "d1", tags=("managed-by-osism", "production"))
+        assert GnmicExtractor()._has_metalbox_tag(device) is False
+
+    def test_tags_with_metalbox_returns_true(self):
+        device = make_device(1, "d1", tags=("production", "managed-by-metalbox"))
+        assert GnmicExtractor()._has_metalbox_tag(device) is True
+
+
+# ---------------------------------------------------------------------------
+# _get_hostname
+#
+# This helper inlines the inventory_hostname logic and deliberately diverges
+# from utils.get_inventory_hostname: it is hasattr-guarded (tolerates devices
+# without a custom_fields attribute, see
+# test_no_custom_fields_attribute_falls_back_to_name) and returns the raw
+# value without str coercion. Do not consolidate the two.
+# ---------------------------------------------------------------------------
+
+
+class TestGetHostname:
+    def test_inventory_hostname_custom_field_used(self):
+        device = make_device(
+            1, "raw-name", custom_fields={"inventory_hostname": "pretty"}
+        )
+        assert GnmicExtractor()._get_hostname(device) == "pretty"
+
+    def test_empty_inventory_hostname_falls_back_to_name(self):
+        device = make_device(1, "raw-name", custom_fields={"inventory_hostname": ""})
+        assert GnmicExtractor()._get_hostname(device) == "raw-name"
+
+    def test_absent_inventory_hostname_falls_back_to_name(self):
+        device = make_device(1, "raw-name", custom_fields={"other": "x"})
+        assert GnmicExtractor()._get_hostname(device) == "raw-name"
+
+    def test_none_custom_fields_falls_back_to_name(self):
+        device = make_device(1, "raw-name", custom_fields=None)
+        assert GnmicExtractor()._get_hostname(device) == "raw-name"
+
+    def test_no_custom_fields_attribute_falls_back_to_name(self):
+        device = SimpleNamespace(name="raw-name")  # no .custom_fields attribute
+        assert GnmicExtractor()._get_hostname(device) == "raw-name"
+
+
+# ---------------------------------------------------------------------------
+# _is_managed_oob_interface
+# ---------------------------------------------------------------------------
+
+
+class TestIsManagedOobInterface:
+    def test_no_tags_returns_false(self):
+        iface = make_interface(id=1, mgmt_only=True, tags=())
+        assert GnmicExtractor()._is_managed_oob_interface(iface) is False
+
+    def test_not_mgmt_only_returns_false(self):
+        iface = make_interface(id=1, mgmt_only=False, tags=("managed-by-osism",))
+        assert GnmicExtractor()._is_managed_oob_interface(iface) is False
+
+    def test_mgmt_only_without_osism_tag_returns_false(self):
+        iface = make_interface(id=1, mgmt_only=True, tags=("managed-by-metalbox",))
+        assert GnmicExtractor()._is_managed_oob_interface(iface) is False
+
+    def test_mgmt_only_with_osism_tag_returns_true(self):
+        iface = make_interface(id=1, mgmt_only=True, tags=("managed-by-osism", "x"))
+        assert GnmicExtractor()._is_managed_oob_interface(iface) is True
+
+
+# ---------------------------------------------------------------------------
+# _get_oob_ip
+# ---------------------------------------------------------------------------
+
+
+class TestGetOobIp:
+    def test_no_api_returns_none_and_warns(self, mock_logger):
+        device = make_device(1, "d1")
+        assert GnmicExtractor(api=None)._get_oob_ip(device) is None
+        assert mock_logger.warning.called
+
+    def test_managed_oob_interface_ip_returned(self):
+        iface = _oob_interface(id=10)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        assert GnmicExtractor(api=api)._get_oob_ip(make_device(1, "d1")) == "192.0.2.10"
+
+    def test_non_managed_interface_skipped(self):
+        iface = make_interface(id=10, mgmt_only=False, tags=("managed-by-osism",))
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        assert GnmicExtractor(api=api)._get_oob_ip(make_device(1, "d1")) is None
+
+    def test_managed_interface_without_ips_returns_none(self):
+        iface = _oob_interface(id=10)
+        api = make_fake_api(interfaces=[iface], ips_by_interface={10: []})
+        assert GnmicExtractor(api=api)._get_oob_ip(make_device(1, "d1")) is None
+
+    def test_ip_without_address_skipped_later_valid_returned(self):
+        iface = _oob_interface(id=10)
+        ips = [SimpleNamespace(), make_ip(""), make_ip("192.0.2.20/24")]
+        api = make_fake_api(interfaces=[iface], ips_by_interface={10: ips})
+        assert GnmicExtractor(api=api)._get_oob_ip(make_device(1, "d1")) == "192.0.2.20"
+
+    def test_interface_filter_exception_returns_none_and_warns(self, mock_logger):
+        api = SimpleNamespace(
+            dcim=SimpleNamespace(
+                interfaces=SimpleNamespace(
+                    filter=MagicMock(side_effect=RuntimeError("boom")),
+                ),
+            ),
+        )
+        assert GnmicExtractor(api=api)._get_oob_ip(make_device(1, "d1")) is None
+        assert mock_logger.warning.called
+
+    def test_filter_called_with_expected_ids(self):
+        iface = _oob_interface(id=10)
+        iface_filter = MagicMock(return_value=[iface])
+        ip_filter = MagicMock(return_value=[make_ip("192.0.2.10/24")])
+        api = SimpleNamespace(
+            dcim=SimpleNamespace(interfaces=SimpleNamespace(filter=iface_filter)),
+            ipam=SimpleNamespace(ip_addresses=SimpleNamespace(filter=ip_filter)),
+        )
+        result = GnmicExtractor(api=api)._get_oob_ip(make_device(7, "d1"))
+        assert result == "192.0.2.10"
+        iface_filter.assert_called_once_with(device_id=7)
+        ip_filter.assert_called_once_with(interface_id=10)
+
+
+# ---------------------------------------------------------------------------
+# extract
+# ---------------------------------------------------------------------------
+
+
+class TestExtract:
+    def test_no_metalbox_tag_returns_none_without_api_calls(self, mock_logger):
+        iface_filter = MagicMock()
+        api = SimpleNamespace(
+            dcim=SimpleNamespace(interfaces=SimpleNamespace(filter=iface_filter)),
+        )
+        device = make_device(1, "d1", tags=("managed-by-osism",))
+        assert GnmicExtractor(api=api).extract(device) is None
+        iface_filter.assert_not_called()  # _get_oob_ip never reached
+        assert mock_logger.debug.called
+
+    def test_tag_but_no_oob_ip_returns_none_and_warns(self, mock_logger):
+        api = make_fake_api(interfaces=[], ips_by_interface={})
+        device = make_device(1, "d1", tags=("managed-by-metalbox",))
+        assert GnmicExtractor(api=api).extract(device) is None
+        assert mock_logger.warning.called
+
+    def test_full_gnmic_config_shape(self):
+        iface = _oob_interface(id=10)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        device = make_device(1, "switch-1", tags=("managed-by-metalbox",))
+        result = GnmicExtractor(api=api).extract(device)
+        assert result == {
+            "gnmic_targets__switch-1": {
+                "192.0.2.10:8080": {
+                    "username": "admin",
+                    "password": "YourPaSsWoRd",
+                    "encoding": "json",
+                    "subscriptions": ["all-interfaces"],
+                }
+            }
+        }
+
+    def test_hostname_honors_inventory_hostname_custom_field(self):
+        iface = _oob_interface(id=10)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        device = make_device(
+            1,
+            "raw-name",
+            tags=("managed-by-metalbox",),
+            custom_fields={"inventory_hostname": "pretty"},
+        )
+        result = GnmicExtractor(api=api).extract(device)
+        assert "gnmic_targets__pretty" in result
+
+    def test_extra_kwargs_are_ignored(self):
+        iface = _oob_interface(id=10)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        device = make_device(1, "switch-1", tags=("managed-by-metalbox",))
+        result = GnmicExtractor(api=api).extract(device, unused="x")
+        assert "gnmic_targets__switch-1" in result
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_primary_ip_extractor.py
+++ b/tests/unit/netbox/test_primary_ip_extractor.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/extractors/primary_ip_extractor.py.
+
+Pure-logic tests: the extractor only reads ``primary_ip4`` / ``primary_ip6`` /
+``primary_ip`` off a device and strips the subnet mask. The three IP attributes
+are attached inline because ``make_device`` does not model them.
+"""
+
+import pytest
+
+from extractors.primary_ip_extractor import PrimaryIPExtractor
+
+from .conftest import make_device, make_ip
+
+
+def _device_with_ips(*, ip4=None, ip6=None, ip=None):
+    """Build a device exposing all three primary-IP attributes."""
+    device = make_device(1, "node1")
+    device.primary_ip4 = ip4
+    device.primary_ip6 = ip6
+    device.primary_ip = ip
+    return device
+
+
+class TestExtract:
+    def test_primary_ip4_strips_mask_and_ignores_ipv6(self):
+        device = _device_with_ips(
+            ip4=make_ip("10.0.0.5/24"),
+            ip6=make_ip("2001:db8::5/64"),
+        )
+        assert PrimaryIPExtractor().extract(device) == "10.0.0.5"
+
+    def test_falls_back_to_ipv6_when_ipv4_absent(self):
+        device = _device_with_ips(ip6=make_ip("2001:db8::5/64"))
+        assert PrimaryIPExtractor().extract(device) == "2001:db8::5"
+
+    def test_legacy_primary_ip_fallback(self):
+        device = _device_with_ips(ip=make_ip("172.16.0.9/16"))
+        assert PrimaryIPExtractor().extract(device) == "172.16.0.9"
+
+    def test_returns_none_when_no_ip_set(self):
+        device = _device_with_ips()
+        assert PrimaryIPExtractor().extract(device) is None
+
+    def test_address_without_mask_returned_unchanged(self):
+        device = _device_with_ips(ip4=make_ip("10.0.0.5"))
+        assert PrimaryIPExtractor().extract(device) == "10.0.0.5"
+
+    def test_ipv4_wins_when_all_three_set(self):
+        device = _device_with_ips(
+            ip4=make_ip("10.0.0.5/24"),
+            ip6=make_ip("2001:db8::5/64"),
+            ip=make_ip("172.16.0.9/16"),
+        )
+        assert PrimaryIPExtractor().extract(device) == "10.0.0.5"
+
+    def test_extra_kwargs_are_ignored(self):
+        device = _device_with_ips(ip4=make_ip("10.0.0.5/24"))
+        assert PrimaryIPExtractor().extract(device, unused="x") == "10.0.0.5"
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_secrets_extractor.py
+++ b/tests/unit/netbox/test_secrets_extractor.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/extractors/secrets_extractor.py.
+
+The extractor reads the ``secrets`` custom field (a dict of Ansible Vault
+values) and drops keys starting with ``remote_board_`` or ``ironic_osism_``.
+It only filters keys -- values (including ``$ANSIBLE_VAULT;`` strings) are
+returned untouched; the ``!vault`` serialization happens later (tier 7).
+"""
+
+import pytest
+
+from extractors.secrets_extractor import SecretsExtractor
+
+from .conftest import make_device
+
+
+def _device(secrets):
+    return make_device(1, "node1", custom_fields={"secrets": secrets})
+
+
+class TestExtract:
+    def test_remote_board_keys_filtered_out(self):
+        secrets = {
+            "bmc_password": "x",
+            "remote_board_username": "u",
+            "remote_board_password": "p",
+        }
+        assert SecretsExtractor().extract(_device(secrets)) == {"bmc_password": "x"}
+
+    def test_ironic_osism_keys_filtered_out(self):
+        secrets = {"keep": "v", "ironic_osism_password": "p"}
+        assert SecretsExtractor().extract(_device(secrets)) == {"keep": "v"}
+
+    def test_substring_match_is_kept(self):
+        # 'x_remote_board_y' contains but does not *start with* a reserved
+        # prefix, so startswith() keeps it.
+        secrets = {"x_remote_board_y": "v"}
+        assert SecretsExtractor().extract(_device(secrets)) == {"x_remote_board_y": "v"}
+
+    def test_only_reserved_keys_returns_none(self):
+        secrets = {"remote_board_username": "u", "ironic_osism_token": "t"}
+        assert SecretsExtractor().extract(_device(secrets)) is None
+
+    def test_none_custom_fields_returns_none(self):
+        device = make_device(1, "node1", custom_fields=None)
+        assert SecretsExtractor().extract(device) is None
+
+    def test_missing_secrets_field_returns_none(self):
+        device = make_device(1, "node1", custom_fields={"other": 1})
+        assert SecretsExtractor().extract(device) is None
+
+    @pytest.mark.parametrize("secrets", [None, "", 0])
+    def test_falsy_secrets_returns_none(self, secrets):
+        assert SecretsExtractor().extract(_device(secrets)) is None
+
+    @pytest.mark.parametrize("secrets", [["a", "b"], "a string"])
+    def test_non_dict_secrets_returns_none(self, secrets):
+        assert SecretsExtractor().extract(_device(secrets)) is None
+
+    def test_vault_values_passed_through_untouched(self):
+        vault = "$ANSIBLE_VAULT;1.1;AES256\n3365343656663230\n"
+        secrets = {"frr_bmc_password": vault, "remote_board_password": vault}
+        result = SecretsExtractor().extract(_device(secrets))
+        # The reserved key is dropped; the kept value is byte-for-byte unchanged.
+        assert result == {"frr_bmc_password": vault}
+        assert result["frr_bmc_password"] == vault
+
+    def test_extra_kwargs_are_ignored(self):
+        assert SecretsExtractor().extract(_device({"keep": "v"}), unused="x") == {
+            "keep": "v"
+        }
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements #543 (sub-issue of #524).

Adds pure-logic unit tests for the five tier-3 *small extractors* under
`files/netbox/extractors/`. No live NetBox is required: the tests build
`SimpleNamespace` device/interface/IP stubs and, for `gnmic_extractor`, a
tiny fake pynetbox session. Builds on the tier-1 (#531) and tier-2 (#538)
foundations and reuses `make_device` / `make_tag` from
`tests/unit/netbox/conftest.py`.

## Change set (commit order)

1. **Add `make_ip` / `make_interface` / `make_fake_api` test factories** —
   extends the netbox conftest with the IP-address, interface and
   pynetbox-session shapes the tier-3 tests need. `make_interface` /
   `make_fake_api` model the `dcim.interfaces.filter` /
   `ipam.ip_addresses.filter` lookups and are reused by tiers 4-9.
2. **Add tier 3 unit tests for primary_ip and config_context** —
   IPv4/IPv6/legacy priority and mask stripping; frr/netplan/`""` key
   filtering, copy-without-mutation and non-dict passthrough.
3. **Add tier 3 unit tests for custom_field and secrets** — required
   `field_name` guard, falsy-but-present values, `None`/empty coercion;
   `remote_board_` / `ironic_osism_` prefix filtering (`startswith`, not
   substring), falsy/non-dict guards, vault values passed through untouched.
4. **Add tier 3 unit tests for the gnmic extractor** — `__init__`,
   `_has_metalbox_tag`, `_get_hostname`, `_is_managed_oob_interface`,
   `_get_oob_ip` (incl. the filter-exception path and `device_id` /
   `interface_id` call args) and `extract` (no-tag short-circuit with no
   API calls, tag-but-no-IP, full `gnmic_targets` shape, inventory_hostname
   key). The module logger is patched with a `MagicMock` via `monkeypatch`
   only where a log assertion documents the branch taken.
5. **Add BaseExtractor abstract-class smoke test** — `BaseExtractor` cannot
   be instantiated; each tier-3 extractor is a concrete subclass.

## Verification

- `pytest tests/unit/netbox` — **259 passed** (184 baseline + 75 new) in ~0.2s.
- Coverage of the five target modules is **100%**
  (`primary_ip`, `config_context`, `custom_field`, `secrets`, `gnmic`).
  `base_extractor.py` reports 83% — the one uncovered line is the `pass`
  body of the abstract method, which is unreachable by definition.
- Tier-3 suite runs in **0.08s** (`--durations=10`, all cases < 5ms).
- `flake8 tests/unit/netbox/` clean; `black --check` clean on all changed
  files.

Note on the coverage command in the issue: the modules are imported as
top-level `extractors.*` (because `files/netbox` is on `sys.path` per
`tests/conftest.py`), so the dotted `--cov=files.netbox.extractors.<mod>`
form does not match the imported module name. The path form
`--cov=files/netbox/extractors` measures coverage correctly and is what the
100% figures above come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)