### PR TITLE
gnmic: Drop unused netbox_client parameter

### DIFF
--- a/files/netbox/data_extractor.py
+++ b/files/netbox/data_extractor.py
@@ -45,7 +45,7 @@ class DeviceDataExtractor:
             netbox_client=netbox_client,
             bulk_loader=bulk_loader,
         )
-        self.gnmic_extractor = GnmicExtractor(api=api, netbox_client=netbox_client)
+        self.gnmic_extractor = GnmicExtractor(api=api)
         self.secrets_extractor = SecretsExtractor()
         self.netbox_client = netbox_client
         self.bulk_loader = bulk_loader

--- a/files/netbox/extractors/gnmic_extractor.py
+++ b/files/netbox/extractors/gnmic_extractor.py
@@ -12,15 +12,13 @@ from .base_extractor import BaseExtractor
 class GnmicExtractor(BaseExtractor):
     """Extracts Gnmic parameters for switches managed by metalbox."""
 
-    def __init__(self, api=None, netbox_client=None):
+    def __init__(self, api=None):
         """Initialize the extractor.
 
         Args:
             api: NetBox API instance (required for interface fetching)
-            netbox_client: NetBox client instance for updating custom fields
         """
         self.api = api
-        self.netbox_client = netbox_client
 
     def extract(self, device: Any, **kwargs) -> Optional[Dict[str, Any]]:
         """Extract Gnmic parameters for metalbox-managed switches.

--- a/tests/unit/netbox/test_gnmic_extractor.py
+++ b/tests/unit/netbox/test_gnmic_extractor.py
@@ -42,14 +42,11 @@ class TestInit:
     def test_defaults(self):
         extractor = GnmicExtractor()
         assert extractor.api is None
-        assert extractor.netbox_client is None
 
     def test_custom_values_are_stored(self):
         api = object()
-        client = object()
-        extractor = GnmicExtractor(api=api, netbox_client=client)
+        extractor = GnmicExtractor(api=api)
         assert extractor.api is api
-        assert extractor.netbox_client is client
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`GnmicExtractor` accepted a `netbox_client` argument and stored it as `self.netbox_client`, but never read it — `extract()` and `_get_oob_ip()` only use `self.api`. The parameter became vestigial in commit b43a618, when GNMI interface lookup was changed from `self.netbox_client.api` to `self.api` directly. Unlike `FRRExtractor` and `NetplanExtractor`, which call `self.netbox_client.update_device_custom_field(...)`, gnmic has no custom-field write-back path requiring `netbox_client`.

## Changes
- Drop the `netbox_client` parameter and attribute from `GnmicExtractor.__init__`.
- Update the sole production call site in `DeviceDataExtractor` (`files/netbox/data_extractor.py`).
- Drop the corresponding assertions from the extractor's constructor tests.

`main.py` is unaffected: it passes `netbox_client` to `InventoryManager` and `GnmicManager`, which indirectly construct `DeviceDataExtractor`; the other extractors there still require it.

## Testing
`tests/unit/netbox/` — 259 passed.