### PR TITLE
Add tier 4 unit tests (bulk_loader, interfaces, connection)

### DIFF
--- a/tests/unit/netbox/conftest.py
+++ b/tests/unit/netbox/conftest.py
@@ -12,11 +12,15 @@ Provides:
   stand-ins for the pynetbox device and tag objects exercised by the tier-2
   modules (filters, device_mapping, parallel_processor). The factories
   intentionally model only the attributes those modules read.
-* ``make_ip`` / ``make_interface`` / ``make_fake_api`` -- factories for the
-  IP-address, interface and pynetbox-session shapes used by the tier-3
-  extractors (primary_ip and gnmic). ``make_interface`` / ``make_fake_api``
+* ``make_ip`` / ``make_interface`` / ``make_vlan`` / ``make_fake_api`` --
+  factories for the IP-address, interface, VLAN and pynetbox-session shapes
+  used by the tier-3 extractors (primary_ip and gnmic) and the tier-4
+  bulk-loader / connection modules. ``make_interface`` / ``make_fake_api``
   model the ``dcim.interfaces.filter`` / ``ipam.ip_addresses.filter`` lookups
-  performed by ``gnmic_extractor`` and are reused by tiers 4-9.
+  performed by ``gnmic_extractor`` and are reused by tiers 4-9. The tier-4
+  attributes (interface ``name`` / ``mac_address`` / ``untagged_vlan`` /
+  ``device`` and IP ``assigned_object_id``) are keyword-only and defaulted so
+  the tier-3 call sites keep working unchanged.
 """
 
 from types import SimpleNamespace
@@ -56,21 +60,49 @@ def make_device(id, name, *, role=None, site=None, tags=(), custom_fields=None):
     )
 
 
-def make_ip(address):
-    """Build a NetBox-shaped IP-address stub with the ``.address`` attribute."""
-    return SimpleNamespace(address=address)
+def make_ip(address, *, assigned_object_id=None):
+    """Build a NetBox-shaped IP-address stub.
+
+    Exposes ``.address`` (read by the primary-IP / gnmic extractors and
+    ``interfaces``) and ``.assigned_object_id`` -- the interface id that
+    ``bulk_loader`` groups IP addresses by. ``assigned_object_id`` is
+    keyword-only and defaulted so the tier-3 call sites keep working.
+    """
+    return SimpleNamespace(address=address, assigned_object_id=assigned_object_id)
 
 
-def make_interface(*, id, mgmt_only, tags=()):
+def make_vlan(vid):
+    """Build a NetBox-shaped VLAN stub with the ``.vid`` attribute."""
+    return SimpleNamespace(vid=vid)
+
+
+def make_interface(
+    *,
+    id,
+    mgmt_only=False,
+    tags=(),
+    name=None,
+    mac_address=None,
+    untagged_vlan=None,
+    device=None,
+):
     """Build a NetBox-shaped interface stub.
 
-    Models only the attributes ``gnmic_extractor`` reads off an interface:
-    ``id``, ``mgmt_only`` and ``tags`` (list of tag stubs).
+    Models the attributes consulted across the interface-handling modules:
+    ``id``, ``mgmt_only`` and ``tags`` (read by ``gnmic_extractor``) plus
+    ``name``, ``mac_address``, ``untagged_vlan`` and ``device`` (read by
+    ``interfaces`` and ``bulk_loader``). The tier-4 additions are keyword-only
+    and defaulted -- including ``mgmt_only`` -- so the tier-3 call sites keep
+    working unchanged. ``name`` defaults to ``eth{id}`` when not given.
     """
     return SimpleNamespace(
         id=id,
         mgmt_only=mgmt_only,
         tags=[make_tag(t) for t in tags],
+        name=name or f"eth{id}",
+        mac_address=mac_address,
+        untagged_vlan=untagged_vlan,
+        device=device,
     )
 
 

--- a/tests/unit/netbox/test_bulk_loader.py
+++ b/tests/unit/netbox/test_bulk_loader.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/bulk_loader.py.
+
+``BulkDataLoader`` wraps the pynetbox session: it loads interfaces and IP
+addresses in batches, caches them, and serves them back grouped by device /
+interface id. The tests use a ``MagicMock`` API (rather than ``make_fake_api``)
+because the per-batch ``call_args_list`` and per-call ``side_effect`` failures
+are exactly what the batching / error-handling branches need to assert. No live
+NetBox is involved.
+
+Interface stubs carry ``.id`` and ``.device.id`` (built with ``make_interface``
+plus a ``SimpleNamespace`` device); IP stubs carry ``.assigned_object_id``
+(built with ``make_ip``). The error-path test deliberately uses an interface
+stub *without* a ``device`` attribute so the grouping loop raises.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from bulk_loader import BulkDataLoader
+
+from .conftest import make_interface, make_ip
+
+
+def _iface(id, device_id):
+    """An interface stub exposing the ``.id`` / ``.device.id`` bulk_loader reads."""
+    return make_interface(id=id, device=SimpleNamespace(id=device_id))
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_defaults(self):
+        loader = BulkDataLoader(MagicMock())
+        assert loader.batch_size == 100
+        assert loader.device_interfaces == {}
+        assert loader.interface_ips == {}
+
+    def test_custom_batch_size_is_stored(self):
+        loader = BulkDataLoader(MagicMock(), batch_size=25)
+        assert loader.batch_size == 25
+
+    def test_class_constant_matches_default(self):
+        assert BulkDataLoader.BATCH_SIZE == 100
+        assert BulkDataLoader(MagicMock()).batch_size == BulkDataLoader.BATCH_SIZE
+
+
+# ---------------------------------------------------------------------------
+# _chunk_list
+# ---------------------------------------------------------------------------
+
+
+class TestChunkList:
+    def test_empty_list(self):
+        assert BulkDataLoader._chunk_list([], 3) == []
+
+    def test_smaller_than_chunk_size(self):
+        assert BulkDataLoader._chunk_list([1, 2], 3) == [[1, 2]]
+
+    def test_exactly_chunk_size(self):
+        assert BulkDataLoader._chunk_list([1, 2, 3], 3) == [[1, 2, 3]]
+
+    def test_one_over_chunk_size(self):
+        assert BulkDataLoader._chunk_list([1, 2, 3, 4], 3) == [[1, 2, 3], [4]]
+
+    def test_exact_multiple_has_no_trailing_empty_chunk(self):
+        assert BulkDataLoader._chunk_list([1, 2, 3, 4, 5, 6], 3) == [
+            [1, 2, 3],
+            [4, 5, 6],
+        ]
+
+    def test_chunk_size_one_yields_one_chunk_per_item(self):
+        assert BulkDataLoader._chunk_list([1, 2, 3], 1) == [[1], [2], [3]]
+
+    def test_order_preserved_round_trips(self):
+        items = list(range(10))
+        chunks = BulkDataLoader._chunk_list(items, 3)
+        assert [item for chunk in chunks for item in chunk] == items
+
+
+# ---------------------------------------------------------------------------
+# load_device_data
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDeviceData:
+    def test_empty_device_ids_makes_no_api_call(self):
+        api = MagicMock()
+        loader = BulkDataLoader(api)
+        loader.load_device_data([])
+        api.dcim.interfaces.filter.assert_not_called()
+        assert loader.device_interfaces == {}
+        assert loader.interface_ips == {}
+
+    def test_single_batch_groups_interfaces_by_device(self):
+        api = MagicMock()
+        i10, i11, i20 = _iface(10, 1), _iface(11, 1), _iface(20, 2)
+        api.dcim.interfaces.filter.return_value = [i10, i11, i20]
+        api.ipam.ip_addresses.filter.return_value = []
+        loader = BulkDataLoader(api)
+        loader.load_device_data([1, 2, 3])
+        api.dcim.interfaces.filter.assert_called_once_with(device_id=[1, 2, 3])
+        assert loader.device_interfaces == {1: [i10, i11], 2: [i20]}
+
+    def test_multi_batch_interface_calls_use_correct_chunks(self):
+        api = MagicMock()
+        api.dcim.interfaces.filter.side_effect = [[], [], []]
+        loader = BulkDataLoader(api, batch_size=2)
+        loader.load_device_data([1, 2, 3, 4, 5])
+        assert api.dcim.interfaces.filter.call_args_list == [
+            call(device_id=[1, 2]),
+            call(device_id=[3, 4]),
+            call(device_id=[5]),
+        ]
+        # No interfaces returned -> the IP lookup is never reached.
+        api.ipam.ip_addresses.filter.assert_not_called()
+
+    def test_ip_addresses_are_batched_and_grouped(self):
+        api = MagicMock()
+        i10, i11, i12 = _iface(10, 1), _iface(11, 1), _iface(12, 1)
+        api.dcim.interfaces.filter.return_value = [i10, i11, i12]
+        ip10 = make_ip("10.0.0.1/24", assigned_object_id=10)
+        ip11 = make_ip("10.0.0.2/24", assigned_object_id=11)
+        ip12 = make_ip("10.0.0.3/24", assigned_object_id=12)
+        api.ipam.ip_addresses.filter.side_effect = [[ip10, ip11], [ip12]]
+        loader = BulkDataLoader(api, batch_size=2)
+        loader.load_device_data([1])
+        assert api.ipam.ip_addresses.filter.call_args_list == [
+            call(interface_id=[10, 11]),
+            call(interface_id=[12]),
+        ]
+        assert loader.interface_ips == {10: [ip10], 11: [ip11], 12: [ip12]}
+
+    def test_partial_interface_batch_failure_continues(self):
+        api = MagicMock()
+        i_a, i_c = _iface(10, 1), _iface(30, 3)
+        api.dcim.interfaces.filter.side_effect = [[i_a], Exception("boom"), [i_c]]
+        api.ipam.ip_addresses.filter.return_value = []
+        loader = BulkDataLoader(api, batch_size=1)
+        loader.load_device_data([1, 2, 3])  # second batch raises, no propagation
+        assert loader.device_interfaces == {1: [i_a], 3: [i_c]}
+
+    def test_partial_ip_batch_failure_continues(self):
+        api = MagicMock()
+        i10, i11, i12 = _iface(10, 1), _iface(11, 1), _iface(12, 1)
+        api.dcim.interfaces.filter.return_value = [i10, i11, i12]
+        ip10 = make_ip("10.0.0.1/24", assigned_object_id=10)
+        ip12 = make_ip("10.0.0.3/24", assigned_object_id=12)
+        api.ipam.ip_addresses.filter.side_effect = [[ip10], Exception("boom"), [ip12]]
+        loader = BulkDataLoader(api, batch_size=1)
+        loader.load_device_data([1])  # second IP batch raises, no propagation
+        assert loader.interface_ips == {10: [ip10], 12: [ip12]}
+
+    def test_no_interfaces_skips_ip_loading(self):
+        api = MagicMock()
+        api.dcim.interfaces.filter.return_value = []
+        loader = BulkDataLoader(api)
+        loader.load_device_data([1, 2])
+        api.ipam.ip_addresses.filter.assert_not_called()
+        assert loader.device_interfaces == {}
+        assert loader.interface_ips == {}
+
+    def test_interface_without_ips_is_absent_from_cache(self):
+        api = MagicMock()
+        i10 = _iface(10, 1)
+        api.dcim.interfaces.filter.return_value = [i10]
+        api.ipam.ip_addresses.filter.return_value = []
+        loader = BulkDataLoader(api)
+        loader.load_device_data([1])
+        assert loader.interface_ips == {}
+        assert loader.get_interface_ip_addresses(i10) == []
+
+    def test_grouping_error_clears_state_and_reraises(self):
+        api = MagicMock()
+        # Interface stub WITHOUT a .device attribute: interface.device.id in
+        # the grouping loop raises AttributeError, caught by the outer except.
+        api.dcim.interfaces.filter.return_value = [SimpleNamespace(id=1)]
+        loader = BulkDataLoader(api)
+        # Pre-seed both caches to prove the error path clears them.
+        loader.device_interfaces[99] = ["stale"]
+        loader.interface_ips[99] = ["stale"]
+        with pytest.raises(AttributeError):
+            loader.load_device_data([1])
+        assert loader.device_interfaces == {}
+        assert loader.interface_ips == {}
+
+    def test_successive_loads_accumulate(self):
+        api = MagicMock()
+        i10, i20 = _iface(10, 1), _iface(20, 2)
+        api.dcim.interfaces.filter.side_effect = [[i10], [i20]]
+        api.ipam.ip_addresses.filter.return_value = []
+        loader = BulkDataLoader(api)
+        loader.load_device_data([1])
+        loader.load_device_data([2])
+        # Caches are additive across calls, not reset per call.
+        assert loader.device_interfaces == {1: [i10], 2: [i20]}
+
+
+# ---------------------------------------------------------------------------
+# get_device_interfaces
+# ---------------------------------------------------------------------------
+
+
+class TestGetDeviceInterfaces:
+    def test_known_device_returns_its_interfaces(self):
+        loader = BulkDataLoader(MagicMock())
+        i10 = _iface(10, 1)
+        loader.device_interfaces[1] = [i10]
+        assert loader.get_device_interfaces(SimpleNamespace(id=1)) == [i10]
+
+    def test_unknown_device_returns_empty_list(self):
+        loader = BulkDataLoader(MagicMock())
+        assert loader.get_device_interfaces(SimpleNamespace(id=999)) == []
+
+
+# ---------------------------------------------------------------------------
+# get_interface_ip_addresses
+# ---------------------------------------------------------------------------
+
+
+class TestGetInterfaceIpAddresses:
+    def test_known_interface_returns_its_ips(self):
+        loader = BulkDataLoader(MagicMock())
+        ip = make_ip("10.0.0.1/24", assigned_object_id=10)
+        loader.interface_ips[10] = [ip]
+        assert loader.get_interface_ip_addresses(SimpleNamespace(id=10)) == [ip]
+
+    def test_unknown_interface_returns_empty_list(self):
+        loader = BulkDataLoader(MagicMock())
+        assert loader.get_interface_ip_addresses(SimpleNamespace(id=999)) == []
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    def test_clear_empties_both_caches(self):
+        api = MagicMock()
+        i10 = _iface(10, 1)
+        api.dcim.interfaces.filter.return_value = [i10]
+        api.ipam.ip_addresses.filter.return_value = [
+            make_ip("10.0.0.1/24", assigned_object_id=10)
+        ]
+        loader = BulkDataLoader(api)
+        loader.load_device_data([1])
+        loader.clear()
+        assert loader.device_interfaces == {}
+        assert loader.interface_ips == {}
+        assert loader.get_device_interfaces(SimpleNamespace(id=1)) == []
+        assert loader.get_interface_ip_addresses(i10) == []
+
+
+# ---------------------------------------------------------------------------
+# get_statistics
+# ---------------------------------------------------------------------------
+
+
+class TestGetStatistics:
+    def test_fresh_loader_reports_zero_counts(self):
+        loader = BulkDataLoader(MagicMock())
+        assert loader.get_statistics() == {
+            "devices": 0,
+            "interfaces": 0,
+            "ip_addresses": 0,
+        }
+
+    def test_counts_sum_across_devices_and_interfaces(self):
+        api = MagicMock()
+        i10, i11, i20 = _iface(10, 1), _iface(11, 1), _iface(20, 2)
+        api.dcim.interfaces.filter.return_value = [i10, i11, i20]
+        api.ipam.ip_addresses.filter.return_value = [
+            make_ip("10.0.0.1/24", assigned_object_id=10),
+            make_ip("10.0.0.2/24", assigned_object_id=11),
+            make_ip("10.0.0.3/24", assigned_object_id=20),
+        ]
+        loader = BulkDataLoader(api)
+        loader.load_device_data([1, 2])  # 2 devices, 2+1 interfaces, 3 IPs
+        assert loader.get_statistics() == {
+            "devices": 2,
+            "interfaces": 3,
+            "ip_addresses": 3,
+        }
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_connection.py
+++ b/tests/unit/netbox/test_connection.py
@@ -126,6 +126,38 @@ class TestConnect:
         assert exc_info.value.__cause__ is boom
         assert patched.sleep.call_count == 2
 
+    def test_ignore_ssl_errors_reruns_per_retry_and_leaks_old_session(
+        self, patched, disable_warnings, monkeypatch
+    ):
+        """Characterize the SSL-ignore x retry intersection.
+
+        With ``ignore_ssl_errors=True`` and a failing probe, ``connect()`` runs
+        ``_configure_ssl_ignore()`` on every attempt and rebinds
+        ``self._session = requests.Session()`` without closing the previous
+        session -- so each retry leaks the prior session (and its connection
+        pool) until GC reclaims it. This test pins that behavior; a future fix
+        that closes the old session before rebinding must update it
+        deliberately.
+        """
+        sessions = []
+
+        def session_factory():
+            session = MagicMock(name=f"session-{len(sessions)}")
+            sessions.append(session)
+            return session
+
+        monkeypatch.setattr(connection.requests, "Session", session_factory)
+        # First probe fails, second succeeds -> two attempts, two sessions.
+        patched.fake_api.dcim.sites.count.side_effect = [Exception("boom"), 5]
+        manager = ConnectionManager(_config(ignore_ssl_errors=True))
+
+        manager.connect()
+
+        assert len(sessions) == 2  # one fresh session per attempt
+        assert disable_warnings.call_count == 2
+        sessions[0].close.assert_not_called()  # the leak: never closed
+        assert manager._session is sessions[1]
+
 
 # ---------------------------------------------------------------------------
 # _configure_ssl_ignore

--- a/tests/unit/netbox/test_connection.py
+++ b/tests/unit/netbox/test_connection.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/connection.py.
+
+``ConnectionManager`` wraps ``pynetbox.api`` with retry and optional SSL-ignore
+handling. The collaborators are monkeypatched in the *module under test's*
+namespace (flat imports): ``connection.pynetbox.api``, ``connection.time.sleep``
+and ``connection.requests`` members. ``time.sleep`` is patched in every
+``connect()`` test so retries never actually wait. The config is a plain
+``SimpleNamespace`` stand-in -- the real ``Config`` is intentionally not used.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import connection
+from connection import ConnectionManager
+from exceptions import NetBoxConnectionError
+
+
+def _config(*, ignore_ssl_errors=False, retry_attempts=3, retry_delay=1):
+    """A minimal Config stand-in exposing only the attributes connect() reads."""
+    return SimpleNamespace(
+        netbox_url="https://netbox.example.com",
+        netbox_token="token-123",
+        ignore_ssl_errors=ignore_ssl_errors,
+        retry_attempts=retry_attempts,
+        retry_delay=retry_delay,
+    )
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch connect()'s collaborators in the connection module namespace.
+
+    ``pynetbox.api`` becomes a factory returning ``fake_api``; ``time.sleep``
+    becomes a no-op spy so retries never wait.
+    """
+    fake_api = MagicMock(name="netbox_api")
+    api_factory = MagicMock(name="pynetbox.api", return_value=fake_api)
+    sleep = MagicMock(name="time.sleep")
+    monkeypatch.setattr(connection.pynetbox, "api", api_factory)
+    monkeypatch.setattr(connection.time, "sleep", sleep)
+    return SimpleNamespace(api_factory=api_factory, fake_api=fake_api, sleep=sleep)
+
+
+@pytest.fixture
+def disable_warnings(monkeypatch):
+    """Spy on requests.packages.urllib3.disable_warnings."""
+    spy = MagicMock(name="disable_warnings")
+    monkeypatch.setattr(connection.requests.packages.urllib3, "disable_warnings", spy)
+    return spy
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_stores_config_and_initializes_state(self):
+        config = _config()
+        manager = ConnectionManager(config)
+        assert manager.config is config
+        assert manager.api is None
+        assert manager._session is None
+
+
+# ---------------------------------------------------------------------------
+# connect
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    def test_success_on_first_attempt(self, patched):
+        patched.fake_api.dcim.sites.count.return_value = 5
+        config = _config()
+        manager = ConnectionManager(config)
+        result = manager.connect()
+        assert result is patched.fake_api
+        patched.api_factory.assert_called_once_with(
+            config.netbox_url, config.netbox_token
+        )
+        patched.sleep.assert_not_called()
+
+    def test_ignore_ssl_errors_configures_session(self, patched, disable_warnings):
+        patched.fake_api.dcim.sites.count.return_value = 5
+        manager = ConnectionManager(_config(ignore_ssl_errors=True))
+        manager.connect()
+        disable_warnings.assert_called_once()
+        assert isinstance(manager.api.http_session, connection.requests.Session)
+        assert manager.api.http_session.verify is False
+
+    def test_no_ssl_branch_leaves_session_untouched(self, patched, disable_warnings):
+        patched.fake_api.dcim.sites.count.return_value = 5
+        manager = ConnectionManager(_config(ignore_ssl_errors=False))
+        manager.connect()
+        disable_warnings.assert_not_called()
+        assert manager._session is None
+
+    def test_retry_then_success_sleeps_once(self, patched):
+        patched.fake_api.dcim.sites.count.side_effect = [Exception("boom"), 5]
+        config = _config()
+        manager = ConnectionManager(config)
+        result = manager.connect()
+        assert result is patched.fake_api
+        patched.sleep.assert_called_once_with(config.retry_delay)
+
+    def test_retry_exhaustion_raises_with_cause(self, patched):
+        boom = RuntimeError("boom")
+        patched.fake_api.dcim.sites.count.side_effect = boom
+        manager = ConnectionManager(_config(retry_attempts=3))
+        with pytest.raises(NetBoxConnectionError) as exc_info:
+            manager.connect()
+        assert exc_info.value.__cause__ is boom
+        assert patched.sleep.call_count == 2  # retry_attempts - 1
+
+    def test_pynetbox_api_raising_uses_retry_path(self, patched):
+        boom = RuntimeError("api down")
+        patched.api_factory.side_effect = boom
+        manager = ConnectionManager(_config(retry_attempts=3))
+        with pytest.raises(NetBoxConnectionError) as exc_info:
+            manager.connect()
+        assert exc_info.value.__cause__ is boom
+        assert patched.sleep.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _configure_ssl_ignore
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureSslIgnore:
+    def test_with_api_attaches_session(self, disable_warnings):
+        manager = ConnectionManager(_config())
+        manager.api = MagicMock()
+        manager._configure_ssl_ignore()
+        disable_warnings.assert_called_once()
+        assert manager._session.verify is False
+        assert manager.api.http_session is manager._session
+
+    def test_with_api_none_creates_session_but_does_not_attach(self, disable_warnings):
+        manager = ConnectionManager(_config())
+        manager.api = None
+        manager._configure_ssl_ignore()  # must not raise (the `if self.api` guard)
+        disable_warnings.assert_called_once()
+        assert isinstance(manager._session, connection.requests.Session)
+        assert manager._session.verify is False
+        assert manager.api is None
+
+
+# ---------------------------------------------------------------------------
+# disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnect:
+    def test_closes_session_and_clears_state(self):
+        manager = ConnectionManager(_config())
+        session = MagicMock()
+        manager._session = session
+        manager.api = MagicMock()
+        manager.disconnect()
+        session.close.assert_called_once()
+        assert manager._session is None
+        assert manager.api is None
+
+    def test_is_idempotent(self):
+        manager = ConnectionManager(_config())
+        manager._session = MagicMock()
+        manager.api = MagicMock()
+        manager.disconnect()
+        manager.disconnect()  # second call hits the `if self._session` guard
+        assert manager._session is None
+        assert manager.api is None
+
+    def test_without_prior_connect_does_not_raise(self):
+        manager = ConnectionManager(_config())
+        manager.disconnect()  # _session and api are already None
+        assert manager._session is None
+        assert manager.api is None
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_interfaces.py
+++ b/tests/unit/netbox/test_interfaces.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/interfaces.py.
+
+``InterfaceHandler`` selects the OOB management interface for a device and
+caches the result. The tests use the *real* ``CacheManager`` (pure in-memory,
+covered by tier 1) so the genuine cache-key round-trip is exercised, plus the
+``make_fake_api`` pynetbox stub for the ``dcim.interfaces.filter`` /
+``ipam.ip_addresses.filter`` lookups. The exception branch swaps in a
+``MagicMock`` whose ``filter`` raises. The module-level ``loguru`` logger is
+patched with a ``MagicMock`` only where a log assertion documents the branch.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cache import CacheManager
+from interfaces import InterfaceHandler
+
+from .conftest import make_device, make_fake_api, make_interface, make_ip, make_vlan
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("interfaces.logger", logger)
+    return logger
+
+
+def _managed(id, *, mac="aa:bb:cc:dd:ee:ff", vlan=None):
+    """A managed OOB interface: mgmt_only with the managed-by-osism tag."""
+    return make_interface(
+        id=id,
+        mgmt_only=True,
+        tags=("managed-by-osism",),
+        mac_address=mac,
+        untagged_vlan=make_vlan(vlan) if vlan is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_default_creates_fresh_cache_manager(self):
+        handler = InterfaceHandler(MagicMock())
+        assert isinstance(handler.cache, CacheManager)
+
+    def test_passed_cache_manager_is_stored(self):
+        cache = CacheManager()
+        handler = InterfaceHandler(MagicMock(), cache_manager=cache)
+        assert handler.cache is cache
+
+
+# ---------------------------------------------------------------------------
+# get_oob_interface
+# ---------------------------------------------------------------------------
+
+
+class TestGetOobInterface:
+    def test_cache_hit_returns_without_api_call(self):
+        api = MagicMock()
+        handler = InterfaceHandler(api)
+        handler.cache.set("oob_interface_1", ("192.0.2.10", "mac", 5))
+        assert handler.get_oob_interface(make_device(1, "d1")) == (
+            "192.0.2.10",
+            "mac",
+            5,
+        )
+        api.dcim.interfaces.filter.assert_not_called()
+
+    def test_ideal_match_returns_ip_mac_vlan_and_caches(self):
+        iface = _managed(10, mac="aa:bb:cc:dd:ee:ff", vlan=5)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        handler = InterfaceHandler(api)
+        result = handler.get_oob_interface(make_device(1, "d1"))
+        assert result == ("192.0.2.10", "aa:bb:cc:dd:ee:ff", 5)
+        assert handler.cache.get("oob_interface_1") == result
+
+    def test_second_call_is_served_from_cache(self):
+        iface = _managed(10, mac="aa:bb:cc:dd:ee:ff", vlan=5)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        handler = InterfaceHandler(api)
+        device = make_device(1, "d1")
+        first = handler.get_oob_interface(device)
+        # Swap in an API that fails if consulted; the cache must answer.
+        guard = MagicMock()
+        guard.dcim.interfaces.filter.side_effect = AssertionError("API touched")
+        handler.api = guard
+        assert handler.get_oob_interface(device) == first
+        guard.dcim.interfaces.filter.assert_not_called()
+
+    def test_ip_bearing_interface_wins_over_earlier_mac_only(self):
+        mac_only = _managed(10, mac="mac-no-ip", vlan=1)
+        ip_bearing = _managed(11, mac="mac-with-ip", vlan=2)
+        api = make_fake_api(
+            interfaces=[mac_only, ip_bearing],
+            ips_by_interface={11: [make_ip("203.0.113.5/24")]},
+        )
+        result = InterfaceHandler(api).get_oob_interface(make_device(1, "d1"))
+        assert result == ("203.0.113.5", "mac-with-ip", 2)
+
+    def test_mac_only_fallback_returns_none_ip_and_caches(self, mock_logger):
+        iface = _managed(10, mac="mac-1", vlan=7)
+        api = make_fake_api(interfaces=[iface], ips_by_interface={})
+        handler = InterfaceHandler(api)
+        result = handler.get_oob_interface(make_device(1, "d1"))
+        assert result == (None, "mac-1", 7)
+        assert mock_logger.info.called
+        assert handler.cache.get("oob_interface_1") == result
+
+    def test_first_mac_only_fallback_wins(self):
+        first = _managed(10, mac="mac-1", vlan=1)
+        second = _managed(11, mac="mac-2", vlan=2)
+        api = make_fake_api(interfaces=[first, second], ips_by_interface={})
+        result = InterfaceHandler(api).get_oob_interface(make_device(1, "d1"))
+        assert result == (None, "mac-1", 1)
+
+    def test_non_mgmt_only_interface_is_skipped(self):
+        iface = make_interface(
+            id=10,
+            mgmt_only=False,
+            tags=("managed-by-osism",),
+            mac_address="mac",
+            untagged_vlan=make_vlan(1),
+        )
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        assert InterfaceHandler(api).get_oob_interface(make_device(1, "d1")) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_interface_without_osism_tag_is_skipped(self):
+        iface = make_interface(
+            id=10,
+            mgmt_only=True,
+            tags=("other",),
+            mac_address="mac",
+            untagged_vlan=make_vlan(1),
+        )
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        assert InterfaceHandler(api).get_oob_interface(make_device(1, "d1")) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_managed_interface_without_mac_is_skipped(self, mock_logger):
+        iface = make_interface(
+            id=10,
+            mgmt_only=True,
+            tags=("managed-by-osism",),
+            mac_address=None,
+            untagged_vlan=make_vlan(1),
+        )
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        result = InterfaceHandler(api).get_oob_interface(make_device(1, "d1"))
+        assert result == (None, None, None)
+        assert mock_logger.debug.called
+
+    def test_no_interfaces_returns_none_tuple_and_caches(self):
+        api = make_fake_api(interfaces=[], ips_by_interface={})
+        handler = InterfaceHandler(api)
+        result = handler.get_oob_interface(make_device(1, "d1"))
+        assert result == (None, None, None)
+        # The negative result is cached (the tuple is not None).
+        assert handler.cache.get("oob_interface_1") == (None, None, None)
+
+    def test_vlan_id_is_extracted_into_result(self):
+        iface = _managed(10, mac="mac", vlan=42)
+        api = make_fake_api(
+            interfaces=[iface],
+            ips_by_interface={10: [make_ip("192.0.2.10/24")]},
+        )
+        result = InterfaceHandler(api).get_oob_interface(make_device(1, "d1"))
+        assert result[2] == 42
+
+    def test_filter_exception_returns_none_tuple_without_caching(self, mock_logger):
+        api = MagicMock()
+        api.dcim.interfaces.filter.side_effect = RuntimeError("boom")
+        handler = InterfaceHandler(api)
+        device = make_device(1, "d1")
+        assert handler.get_oob_interface(device) == (None, None, None)
+        assert mock_logger.warning.called
+        # The except path skips cache.set, so the result is not cached...
+        assert handler.cache.get("oob_interface_1") is None
+        # ...and a subsequent call queries the API again.
+        handler.get_oob_interface(device)
+        assert api.dcim.interfaces.filter.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _is_managed_oob_interface
+#
+# Unlike the gnmic_extractor twin (#543), this reads interface.tags directly
+# with no hasattr guard -- interface stubs must always define tags.
+# ---------------------------------------------------------------------------
+
+
+class TestIsManagedOobInterface:
+    @staticmethod
+    def _handler():
+        return InterfaceHandler(MagicMock())
+
+    def test_empty_tags_returns_false(self):
+        iface = make_interface(id=1, mgmt_only=True, tags=())
+        assert self._handler()._is_managed_oob_interface(iface) is False
+
+    def test_falsy_tags_returns_false(self):
+        iface = SimpleNamespace(tags=None, mgmt_only=True)
+        assert self._handler()._is_managed_oob_interface(iface) is False
+
+    def test_not_mgmt_only_returns_false(self):
+        iface = make_interface(id=1, mgmt_only=False, tags=("managed-by-osism",))
+        assert self._handler()._is_managed_oob_interface(iface) is False
+
+    def test_mgmt_only_without_osism_tag_returns_false(self):
+        iface = make_interface(id=1, mgmt_only=True, tags=("other",))
+        assert self._handler()._is_managed_oob_interface(iface) is False
+
+    def test_mgmt_only_with_osism_tag_among_others_returns_true(self):
+        iface = make_interface(id=1, mgmt_only=True, tags=("other", "managed-by-osism"))
+        assert self._handler()._is_managed_oob_interface(iface) is True
+
+    def test_interface_without_tags_attribute_raises(self):
+        iface = SimpleNamespace(mgmt_only=True)  # no tags attribute at all
+        with pytest.raises(AttributeError):
+            self._handler()._is_managed_oob_interface(iface)
+
+
+# ---------------------------------------------------------------------------
+# _get_vlan_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetVlanId:
+    @staticmethod
+    def _handler():
+        return InterfaceHandler(MagicMock())
+
+    def test_untagged_vlan_with_vid_returns_vid(self):
+        iface = make_interface(id=1, untagged_vlan=make_vlan(100))
+        assert self._handler()._get_vlan_id(iface) == 100
+
+    def test_untagged_vlan_none_returns_none(self):
+        iface = make_interface(id=1, untagged_vlan=None)
+        assert self._handler()._get_vlan_id(iface) is None
+
+    def test_missing_untagged_vlan_attribute_returns_none(self):
+        iface = SimpleNamespace()  # no untagged_vlan attribute -> hasattr guard
+        assert self._handler()._get_vlan_id(iface) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_interface_ip
+# ---------------------------------------------------------------------------
+
+
+class TestGetInterfaceIp:
+    def test_first_ip_has_mask_stripped(self):
+        api = make_fake_api(ips_by_interface={1: [make_ip("10.0.0.5/24")]})
+        assert InterfaceHandler(api)._get_interface_ip(make_interface(id=1)) == (
+            "10.0.0.5"
+        )
+
+    def test_only_first_ip_is_returned(self):
+        api = make_fake_api(
+            ips_by_interface={1: [make_ip("10.0.0.5/24"), make_ip("10.0.0.6/24")]}
+        )
+        assert InterfaceHandler(api)._get_interface_ip(make_interface(id=1)) == (
+            "10.0.0.5"
+        )
+
+    def test_no_ips_returns_none(self):
+        api = make_fake_api(ips_by_interface={})
+        assert InterfaceHandler(api)._get_interface_ip(make_interface(id=1)) is None
+
+    def test_filter_called_with_interface_id(self):
+        api = MagicMock()
+        api.ipam.ip_addresses.filter.return_value = [make_ip("10.0.0.5/24")]
+        assert InterfaceHandler(api)._get_interface_ip(make_interface(id=7)) == (
+            "10.0.0.5"
+        )
+        api.ipam.ip_addresses.filter.assert_called_once_with(interface_id=7)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    pytest.main([__file__, "-v"])

--- a/tests/unit/netbox/test_interfaces.py
+++ b/tests/unit/netbox/test_interfaces.py
@@ -213,8 +213,8 @@ class TestGetOobInterface:
 # ---------------------------------------------------------------------------
 # _is_managed_oob_interface
 #
-# Unlike the gnmic_extractor twin (#543), this reads interface.tags directly
-# with no hasattr guard -- interface stubs must always define tags.
+# This reads interface.tags directly with no hasattr guard -- interface stubs
+# must always define tags.
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Implements #546 (tier 4 of the meta test-coverage effort #524).

Adds unit tests for the **bulk loader & connection** modules under
`files/netbox/` — `bulk_loader.py`, `interfaces.py` and `connection.py`.
This is the first tier where the code under test wraps the pynetbox
session itself, so the tests move from `SimpleNamespace`-only fakes to
`MagicMock`-backed sessions where call counts, call arguments and
per-call `side_effect` failures matter. No live NetBox is required.

All three modules reach **100% line coverage** and the tier-4 suite runs
in well under a second with no real waiting.

## Change set (commit order)

1. **Extend conftest factories for tier 4 modules** — extends the
   `tests/unit/netbox/conftest.py` factories introduced in #543, all
   backward-compatibly (keyword-only, defaulted), so the tier-3 tests
   keep passing unchanged:
   - `make_interface` gains `name`, `mac_address`, `untagged_vlan`,
     `device` (and `mgmt_only` now defaults to `False`)
   - `make_ip` gains a keyword-only `assigned_object_id`
   - new `make_vlan(vid)` helper

2. **Add tier 4 unit tests for the bulk loader** — `test_bulk_loader.py`
   drives `BulkDataLoader` with a `MagicMock` pynetbox session:
   constructor defaults / `BATCH_SIZE` parity, `_chunk_list` edge cases,
   `load_device_data` (empty short-circuit, single/multi-batch interface
   loading asserted via `call_args_list`, IP batching + grouping, partial
   per-batch failures that `continue`, the no-interfaces skip, the
   grouping `AttributeError` that clears state and re-raises, additive
   accumulation across calls), the cache getters, `clear()` and
   `get_statistics()`.

3. **Add tier 4 unit tests for the interface handler** —
   `test_interfaces.py` uses the *real* in-memory `CacheManager` and the
   `make_fake_api` stub: `get_oob_interface` cache hit / ideal IP+MAC
   match / cached-on-second-call / IP-preferred-over-MAC-only /
   MAC-only fallback / first-fallback-wins / skip rules / cached negative
   result / VLAN extraction / filter-exception-without-caching, plus the
   `_is_managed_oob_interface` truth table (including the no-`hasattr`
   asymmetry vs. the gnmic twin), `_get_vlan_id` and `_get_interface_ip`.

4. **Add tier 4 unit tests for the connection manager** —
   `test_connection.py` monkeypatches `connection.pynetbox.api`,
   `connection.time.sleep` and the `connection.requests` SSL helpers in
   the module-under-test namespace; `time.sleep` is patched in every
   `connect()` test. Covers `__init__`, `connect` (first-attempt success,
   the SSL-ignore branch, the no-SSL branch, retry-then-success,
   retry exhaustion raising `NetBoxConnectionError` chained from the
   original cause, and `pynetbox.api` itself raising),
   `_configure_ssl_ignore` (with and without `self.api`), and
   `disconnect` (close, idempotency, no-prior-connect).

## Verification

- `pytest tests/unit` — 325 passed
- `pytest --cov=bulk_loader --cov=interfaces --cov=connection` — 100% on
  all three modules
- `pytest --durations=10` — tier-4 suite 0.17s, all durations <0.005s
- `flake8 files tests` — clean
- `black --check` on the four touched files — clean

## Notes

- Coverage is invoked as `--cov=bulk_loader` (etc.) rather than the
  issue's `--cov=files.netbox.bulk_loader`: the test harness puts
  `files/netbox/` on `sys.path` (see `tests/conftest.py`) so the modules
  import flat, and the flat name is what coverage matches. The reported
  file is still `files/netbox/bulk_loader.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)