### PR TITLE
Set accept-ra: False for BGP unnumbered leaf connections

### DIFF
--- a/files/netbox/extractors/netplan_extractor.py
+++ b/files/netbox/extractors/netplan_extractor.py
@@ -557,6 +557,7 @@ class NetplanExtractor(BaseExtractor):
             ) and not self._interface_has_ip_addresses(interface):
                 # Add leaf-specific parameters
                 interface_config["link-local"] = ["ipv6"]
+                interface_config["accept-ra"] = False
                 interface_config["dhcp4"] = False
                 interface_config["dhcp6"] = False
 


### PR DESCRIPTION
By default, the nodes will receive RAs and install those IPv6 routes to the kernel. This is not desired in this use case, as routes should be installed by BGP only