### PR TITLE
Add tier 6 unit tests for the dnsmasq package

### DIFF
--- a/tests/unit/netbox/conftest.py
+++ b/tests/unit/netbox/conftest.py
@@ -17,6 +17,14 @@ Provides:
   extractors (primary_ip and gnmic). ``make_interface`` / ``make_fake_api``
   model the ``dcim.interfaces.filter`` / ``ipam.ip_addresses.filter`` lookups
   performed by ``gnmic_extractor`` and are reused by tiers 4-9.
+* ``make_iface_type`` / ``make_vlan`` / ``make_vlan_group`` / ``make_prefix``
+  / ``make_dnsmasq_config`` -- additional shapes consumed by the tier-6
+  dnsmasq tests. ``make_interface`` gains the ``type`` / ``label`` / ``name``
+  / ``untagged_vlan`` / ``connected_endpoints`` / ``enabled`` attributes the
+  dnsmasq interface gating reads, ``make_device`` gains ``device_type`` for
+  the MAC-entry fallback and ``make_fake_api`` gains ``prefixes`` to back
+  ``ipam.prefixes.filter(tag=...)``. Every addition is keyword-only and
+  defaulted so the tier 1-5 callers keep working unchanged.
 """
 
 from types import SimpleNamespace
@@ -37,14 +45,19 @@ def make_tag(slug):
     return SimpleNamespace(slug=slug)
 
 
-def make_device(id, name, *, role=None, site=None, tags=(), custom_fields=None):
+def make_device(
+    id, name, *, role=None, site=None, tags=(), custom_fields=None, device_type=None
+):
     """Build a NetBox-shaped device stub.
 
     Only the attributes consulted by the modules under test are populated:
-    ``id``, ``name``, ``role``, ``site``, ``tags`` (list of tag stubs) and
-    ``custom_fields`` (plain dict). ``role`` and ``site`` accept any object
-    exposing a ``.slug`` attribute -- pass ``make_tag("...")`` for the common
-    case or build a custom ``SimpleNamespace`` when extra fields are needed.
+    ``id``, ``name``, ``role``, ``site``, ``tags`` (list of tag stubs),
+    ``custom_fields`` (plain dict) and ``device_type``. ``role`` and ``site``
+    accept any object exposing a ``.slug`` attribute -- pass ``make_tag("...")``
+    for the common case or build a custom ``SimpleNamespace`` when extra fields
+    are needed. ``device_type`` defaults to ``None`` and accepts a
+    ``SimpleNamespace(slug="...")`` for the dnsmasq MAC-entry device-type
+    fallback.
     """
     return SimpleNamespace(
         id=id,
@@ -53,6 +66,7 @@ def make_device(id, name, *, role=None, site=None, tags=(), custom_fields=None):
         site=site,
         tags=[make_tag(t) for t in tags],
         custom_fields=custom_fields if custom_fields is not None else {},
+        device_type=device_type,
     )
 
 
@@ -61,25 +75,81 @@ def make_ip(address):
     return SimpleNamespace(address=address)
 
 
-def make_interface(*, id, mgmt_only, tags=()):
+def make_iface_type(value):
+    """Build a NetBox-shaped interface-type stub with the ``.value`` attribute.
+
+    The dnsmasq interface gating tests virtual interfaces via
+    ``interface.type.value == "virtual"``.
+    """
+    return SimpleNamespace(value=value)
+
+
+def make_vlan(vid, *, group=None):
+    """Build a NetBox-shaped VLAN stub.
+
+    Exposes ``vid`` and an optional ``group`` (a ``make_vlan_group(...)`` stub)
+    used by the dnsmasq routed-group check.
+    """
+    return SimpleNamespace(vid=vid, group=group)
+
+
+def make_vlan_group(name):
+    """Build a NetBox-shaped VLAN-group stub with the ``.name`` attribute."""
+    return SimpleNamespace(name=name)
+
+
+def make_prefix(prefix, *, vlan=None):
+    """Build a NetBox-shaped OOB network / prefix stub.
+
+    Exposes ``prefix`` (a CIDR string) and an optional ``vlan``
+    (a ``make_vlan(...)`` stub).
+    """
+    return SimpleNamespace(prefix=prefix, vlan=vlan)
+
+
+def make_interface(
+    *,
+    id,
+    mgmt_only=False,
+    tags=(),
+    name=None,
+    label=None,
+    type=None,
+    untagged_vlan=None,
+    connected_endpoints=None,
+    enabled=True,
+):
     """Build a NetBox-shaped interface stub.
 
-    Models only the attributes ``gnmic_extractor`` reads off an interface:
-    ``id``, ``mgmt_only`` and ``tags`` (list of tag stubs).
+    Models the attributes ``gnmic_extractor`` reads off an interface (``id``,
+    ``mgmt_only`` and ``tags``) plus the attributes the dnsmasq interface
+    gating consults: ``name``, ``label``, ``type`` (a ``make_iface_type(...)``
+    stub), ``untagged_vlan`` (a ``make_vlan(...)`` stub), ``connected_endpoints``
+    and ``enabled``. All dnsmasq attributes are keyword-only and defaulted so
+    the tier-3 callers (``make_interface(id=..., mgmt_only=..., tags=...)``)
+    keep working unchanged.
     """
     return SimpleNamespace(
         id=id,
         mgmt_only=mgmt_only,
         tags=[make_tag(t) for t in tags],
+        name=name,
+        label=label,
+        type=type,
+        untagged_vlan=untagged_vlan,
+        connected_endpoints=connected_endpoints,
+        enabled=enabled,
     )
 
 
-def make_fake_api(interfaces=(), ips_by_interface=None):
+def make_fake_api(interfaces=(), ips_by_interface=None, prefixes=()):
     """Build a pynetbox-shaped API session stub.
 
-    Exposes ``dcim.interfaces.filter(device_id=...)`` returning ``interfaces``
-    and ``ipam.ip_addresses.filter(interface_id=...)`` returning the addresses
-    registered for that interface id in ``ips_by_interface`` (default empty).
+    Exposes ``dcim.interfaces.filter(device_id=...)`` returning ``interfaces``,
+    ``ipam.ip_addresses.filter(interface_id=...)`` returning the addresses
+    registered for that interface id in ``ips_by_interface`` (default empty)
+    and ``ipam.prefixes.filter(tag=...)`` returning ``prefixes`` (default
+    empty), used by the dnsmasq metalbox DHCP-option collector.
     """
     ips_by_interface = ips_by_interface or {}
     return SimpleNamespace(
@@ -94,5 +164,30 @@ def make_fake_api(interfaces=(), ips_by_interface=None):
                     ips_by_interface.get(interface_id, [])
                 ),
             ),
+            prefixes=SimpleNamespace(
+                filter=lambda tag: list(prefixes),
+            ),
         ),
+    )
+
+
+def make_dnsmasq_config(
+    tmp_path,
+    *,
+    reconciler_mode="manager",
+    dnsmasq_lease_time="28d",
+    dnsmasq_switch_roles=("leaf",),
+):
+    """Build a config stub for the dnsmasq modules.
+
+    Mirrors the four ``Config`` attributes the dnsmasq package reads --
+    ``reconciler_mode``, ``inventory_path`` (the pytest ``tmp_path`` used as the
+    inventory root), ``dnsmasq_lease_time`` and ``dnsmasq_switch_roles`` -- as a
+    ``SimpleNamespace`` so tests need not import the real ``Config``.
+    """
+    return SimpleNamespace(
+        reconciler_mode=reconciler_mode,
+        inventory_path=tmp_path,
+        dnsmasq_lease_time=dnsmasq_lease_time,
+        dnsmasq_switch_roles=list(dnsmasq_switch_roles),
     )

--- a/tests/unit/netbox/test_dnsmasq_base.py
+++ b/tests/unit/netbox/test_dnsmasq_base.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/dnsmasq/base.py.
+
+``DnsmasqBase.write_dnsmasq_to_device`` resolves a device's host_vars location
+by globbing ``host_vars/{hostname}*`` under ``config.inventory_path`` (pytest's
+``tmp_path``) and writes / appends a ``999-netbox-dnsmasq.yml`` file. The tests
+pre-create the four glob shapes (existing dir, existing single file, no match,
+multiple matches) in the real temp tree and assert on the files produced. The
+module-level ``loguru`` logger is patched only where a log assertion documents
+the branch taken.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from dnsmasq.base import DnsmasqBase
+
+from .conftest import make_device, make_dnsmasq_config
+
+DATA = {"dnsmasq_dhcp_hosts__node1": ["aa:bb:cc:dd:ee:ff,node1,192.0.2.10"]}
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("dnsmasq.base.logger", logger)
+    return logger
+
+
+def _base(tmp_path, **overrides):
+    return DnsmasqBase(make_dnsmasq_config(tmp_path, **overrides))
+
+
+class TestWriteDnsmasqToDevice:
+    def test_existing_directory_match_writes_inside(self, tmp_path):
+        (tmp_path / "host_vars" / "node1").mkdir(parents=True)
+        base = _base(tmp_path)
+
+        base.write_dnsmasq_to_device(make_device(1, "node1"), DATA)
+
+        output = tmp_path / "host_vars" / "node1" / "999-netbox-dnsmasq.yml"
+        assert output.exists()
+        assert yaml.safe_load(output.read_text()) == DATA
+
+    def test_existing_single_file_match_appends_with_separator(self, tmp_path):
+        (tmp_path / "host_vars").mkdir(parents=True)
+        target = tmp_path / "host_vars" / "node1"
+        target.write_text("seed: 1\n")
+        base = _base(tmp_path)
+
+        base.write_dnsmasq_to_device(make_device(1, "node1"), DATA)
+
+        content = target.read_text()
+        # Prior content is preserved and the new block is appended after the
+        # "# NetBox dnsmasq" separator.
+        assert content.startswith("seed: 1\n")
+        assert "\n# NetBox dnsmasq\n" in content
+        assert "dnsmasq_dhcp_hosts__node1" in content
+
+    def test_no_match_creates_directory_and_writes(self, tmp_path):
+        (tmp_path / "host_vars").mkdir(parents=True)
+        base = _base(tmp_path)
+
+        base.write_dnsmasq_to_device(make_device(1, "node1"), DATA)
+
+        output = tmp_path / "host_vars" / "node1" / "999-netbox-dnsmasq.yml"
+        assert output.exists()
+        assert yaml.safe_load(output.read_text()) == DATA
+
+    def test_multiple_matches_warns_and_writes_nothing(self, tmp_path, mock_logger):
+        (tmp_path / "host_vars" / "node1").mkdir(parents=True)
+        (tmp_path / "host_vars" / "node1x").mkdir(parents=True)
+        base = _base(tmp_path)
+
+        base.write_dnsmasq_to_device(make_device(1, "node1"), DATA)
+
+        mock_logger.warning.assert_called_once()
+        assert not (
+            tmp_path / "host_vars" / "node1" / "999-netbox-dnsmasq.yml"
+        ).exists()
+        assert not (
+            tmp_path / "host_vars" / "node1x" / "999-netbox-dnsmasq.yml"
+        ).exists()
+
+    def test_inventory_hostname_custom_field_drives_glob_target(self, tmp_path):
+        (tmp_path / "host_vars" / "pretty").mkdir(parents=True)
+        base = _base(tmp_path)
+        device = make_device(1, "raw", custom_fields={"inventory_hostname": "pretty"})
+
+        base.write_dnsmasq_to_device(device, DATA)
+
+        assert (tmp_path / "host_vars" / "pretty" / "999-netbox-dnsmasq.yml").exists()
+        assert not (tmp_path / "host_vars" / "raw").exists()

--- a/tests/unit/netbox/test_dnsmasq_dhcp_config.py
+++ b/tests/unit/netbox/test_dnsmasq_dhcp_config.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/dnsmasq/dhcp_config.py.
+
+The ``DHCPConfigGenerator`` turns the OOB view of a device into dnsmasq DHCP
+host / MAC entries and writes OOB DHCP ranges into the generated inventory
+tree. The host/MAC formatting tests drive plain ``SimpleNamespace`` device
+stubs; ``write_dhcp_ranges`` writes under ``config.inventory_path`` (pytest's
+``tmp_path``) through a ``MagicMock``-backed fake ``NetBoxClient`` whose
+``get_oob_networks()`` return value is stubbed per scenario. The module-level
+``loguru`` logger is patched with a ``MagicMock`` only where a log assertion
+documents the branch taken.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from dnsmasq.dhcp_config import DHCPConfigGenerator
+
+from .conftest import make_device, make_dnsmasq_config, make_prefix
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("dnsmasq.dhcp_config.logger", logger)
+    return logger
+
+
+def _gen(tmp_path, **overrides):
+    """Build a DHCPConfigGenerator with a dnsmasq config stub."""
+    return DHCPConfigGenerator(make_dnsmasq_config(tmp_path, **overrides))
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_stores_config(self, tmp_path):
+        config = make_dnsmasq_config(tmp_path)
+        assert DHCPConfigGenerator(config).config is config
+
+
+# ---------------------------------------------------------------------------
+# generate_dhcp_host_entry
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDhcpHostEntry:
+    def test_plain_entry_lowercases_mac_and_uses_hostname(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "node1")
+        entry = gen.generate_dhcp_host_entry(device, "192.0.2.10", "AA:BB:CC:DD:EE:FF")
+        assert entry == "aa:bb:cc:dd:ee:ff,node1,192.0.2.10"
+
+    def test_explicit_set_tag_wins_even_with_vlan_id(self, tmp_path):
+        # set_tag branch precedes the vlan branch, even in metalbox mode.
+        gen = _gen(tmp_path, reconciler_mode="metalbox")
+        device = make_device(1, "node1")
+        entry = gen.generate_dhcp_host_entry(
+            device, "192.0.2.10", "aa:bb:cc:dd:ee:ff", vlan_id=100, set_tag="oob"
+        )
+        assert entry == "aa:bb:cc:dd:ee:ff,node1,192.0.2.10,set:oob"
+
+    def test_vlan_id_in_metalbox_mode_adds_vlan_tag(self, tmp_path):
+        gen = _gen(tmp_path, reconciler_mode="metalbox")
+        device = make_device(1, "node1")
+        entry = gen.generate_dhcp_host_entry(
+            device, "192.0.2.10", "aa:bb:cc:dd:ee:ff", vlan_id=100
+        )
+        assert entry == "aa:bb:cc:dd:ee:ff,node1,192.0.2.10,set:vlan100"
+
+    def test_vlan_id_ignored_outside_metalbox_mode(self, tmp_path):
+        gen = _gen(tmp_path, reconciler_mode="manager")
+        device = make_device(1, "node1")
+        entry = gen.generate_dhcp_host_entry(
+            device, "192.0.2.10", "aa:bb:cc:dd:ee:ff", vlan_id=100
+        )
+        assert entry == "aa:bb:cc:dd:ee:ff,node1,192.0.2.10"
+
+    def test_hostname_honours_inventory_hostname_custom_field(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(
+            1, "raw-name", custom_fields={"inventory_hostname": "pretty"}
+        )
+        entry = gen.generate_dhcp_host_entry(device, "192.0.2.10", "aa:bb:cc:dd:ee:ff")
+        assert entry == "aa:bb:cc:dd:ee:ff,pretty,192.0.2.10"
+
+    def test_hostname_falls_back_to_device_name(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "raw-name", custom_fields={})
+        entry = gen.generate_dhcp_host_entry(device, "192.0.2.10", "aa:bb:cc:dd:ee:ff")
+        assert entry == "aa:bb:cc:dd:ee:ff,raw-name,192.0.2.10"
+
+
+# ---------------------------------------------------------------------------
+# generate_dhcp_mac_entry
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDhcpMacEntry:
+    def test_priority1_custom_dhcp_tag(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "n", custom_fields={"dnsmasq_dhcp_tag": "customtag"})
+        assert (
+            gen.generate_dhcp_mac_entry(device, "AA:BB:CC:DD:EE:FF")
+            == "set:customtag,aa:bb:cc:dd:ee:ff"
+        )
+
+    def test_priority2_managed_by_ironic_tag(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "n", tags=("managed-by-ironic",))
+        assert (
+            gen.generate_dhcp_mac_entry(device, "AA:BB:CC:DD:EE:FF")
+            == "set:ironic,aa:bb:cc:dd:ee:ff"
+        )
+
+    def test_priority3_device_type_slug(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "n", device_type=SimpleNamespace(slug="server"))
+        assert (
+            gen.generate_dhcp_mac_entry(device, "AA:BB:CC:DD:EE:FF")
+            == "set:server,aa:bb:cc:dd:ee:ff"
+        )
+
+    def test_custom_tag_wins_over_ironic_and_device_type(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(
+            1,
+            "n",
+            tags=("managed-by-ironic",),
+            custom_fields={"dnsmasq_dhcp_tag": "customtag"},
+            device_type=SimpleNamespace(slug="server"),
+        )
+        assert (
+            gen.generate_dhcp_mac_entry(device, "aa:bb:cc:dd:ee:ff")
+            == "set:customtag,aa:bb:cc:dd:ee:ff"
+        )
+
+    def test_ironic_wins_over_device_type(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(
+            1,
+            "n",
+            tags=("managed-by-ironic",),
+            device_type=SimpleNamespace(slug="server"),
+        )
+        assert (
+            gen.generate_dhcp_mac_entry(device, "aa:bb:cc:dd:ee:ff")
+            == "set:ironic,aa:bb:cc:dd:ee:ff"
+        )
+
+    def test_no_tag_source_returns_none(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "n")
+        assert gen.generate_dhcp_mac_entry(device, "aa:bb:cc:dd:ee:ff") is None
+
+    def test_device_type_without_slug_returns_none(self, tmp_path):
+        gen = _gen(tmp_path)
+        device = make_device(1, "n", device_type=SimpleNamespace(slug=None))
+        assert gen.generate_dhcp_mac_entry(device, "aa:bb:cc:dd:ee:ff") is None
+
+
+# ---------------------------------------------------------------------------
+# write_dhcp_ranges
+# ---------------------------------------------------------------------------
+
+
+def _range_file(tmp_path):
+    return tmp_path / "group_vars" / "manager" / "999-netbox-dnsmasq-dhcp-range.yml"
+
+
+class TestWriteDhcpRanges:
+    def test_no_oob_networks_writes_nothing(self, tmp_path, mock_logger):
+        gen = _gen(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = []
+
+        gen.write_dhcp_ranges(client)
+
+        assert not _range_file(tmp_path).exists()
+        mock_logger.debug.assert_called_once()
+
+    def test_ipv4_without_prefix_tags(self, tmp_path):
+        gen = _gen(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = [make_prefix("192.0.2.0/24")]
+
+        gen.write_dhcp_ranges(client)
+
+        output_file = _range_file(tmp_path)
+        assert output_file.exists()
+        data = yaml.safe_load(output_file.read_text())
+        assert isinstance(data["dnsmasq_dhcp_ranges"], list)
+        assert data["dnsmasq_dhcp_ranges"] == ["192.0.2.0,static,255.255.255.0,28d"]
+
+    def test_ipv6_network_is_skipped(self, tmp_path):
+        gen = _gen(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = [make_prefix("2001:db8::/64")]
+
+        gen.write_dhcp_ranges(client)
+
+        assert not _range_file(tmp_path).exists()
+
+    def test_prefix_tags_only_emits_mapped_prefixes(self, tmp_path):
+        gen = _gen(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = [
+            make_prefix("192.0.2.0/24"),
+            make_prefix("198.51.100.0/24"),
+        ]
+
+        gen.write_dhcp_ranges(client, prefix_tags={"192.0.2.0/24": "oob"})
+
+        data = yaml.safe_load(_range_file(tmp_path).read_text())
+        assert data["dnsmasq_dhcp_ranges"] == [
+            "set:oob,192.0.2.0,static,255.255.255.0,28d"
+        ]
+
+    def test_malformed_prefix_warns_and_continues(self, tmp_path, mock_logger):
+        gen = _gen(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = [
+            make_prefix("nope"),
+            make_prefix("192.0.2.0/24"),
+        ]
+
+        gen.write_dhcp_ranges(client)
+
+        mock_logger.warning.assert_called_once()
+        data = yaml.safe_load(_range_file(tmp_path).read_text())
+        assert data["dnsmasq_dhcp_ranges"] == ["192.0.2.0,static,255.255.255.0,28d"]
+
+    def test_all_networks_invalid_writes_nothing(self, tmp_path):
+        gen = _gen(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = [make_prefix("nope")]
+
+        gen.write_dhcp_ranges(client)
+
+        assert not _range_file(tmp_path).exists()
+
+    def test_lease_time_is_read_from_config(self, tmp_path):
+        gen = _gen(tmp_path, dnsmasq_lease_time="12h")
+        client = MagicMock()
+        client.get_oob_networks.return_value = [make_prefix("192.0.2.0/24")]
+
+        gen.write_dhcp_ranges(client)
+
+        data = yaml.safe_load(_range_file(tmp_path).read_text())
+        assert data["dnsmasq_dhcp_ranges"] == ["192.0.2.0,static,255.255.255.0,12h"]

--- a/tests/unit/netbox/test_dnsmasq_interface_handler.py
+++ b/tests/unit/netbox/test_dnsmasq_interface_handler.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/dnsmasq/interface_handler.py.
+
+``InterfaceHandler.get_virtual_interfaces_for_dnsmasq`` is a static method that
+selects virtual interfaces carrying the ``managed-by-osism`` tag and an
+untagged VLAN, returning the label (preferred) or name of each. Interfaces are
+read through a pynetbox session faked by ``make_fake_api`` (plain lists) or, for
+the filter-raises branch, a ``MagicMock`` with a ``side_effect``. The
+module-level ``loguru`` logger is patched only where a log assertion documents
+the branch taken.
+
+Note: this is ``dnsmasq.interface_handler.InterfaceHandler`` -- distinct from
+the unrelated ``interfaces.InterfaceHandler`` class elsewhere in the package.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dnsmasq.interface_handler import InterfaceHandler
+
+from .conftest import (
+    make_device,
+    make_fake_api,
+    make_iface_type,
+    make_interface,
+    make_vlan,
+)
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("dnsmasq.interface_handler.logger", logger)
+    return logger
+
+
+def _virtual(**overrides):
+    """A qualifying virtual interface (managed-by-osism + untagged VLAN)."""
+    params = dict(
+        id=1,
+        type=make_iface_type("virtual"),
+        tags=("managed-by-osism",),
+        untagged_vlan=make_vlan(100),
+        label="oob1",
+        name="eth0",
+    )
+    params.update(overrides)
+    return make_interface(**params)
+
+
+def _call(interfaces, client=None):
+    device = make_device(1, "d1")
+    if client is None:
+        client = MagicMock()
+        client.api = make_fake_api(interfaces=interfaces)
+    return InterfaceHandler.get_virtual_interfaces_for_dnsmasq(device, client)
+
+
+class TestGetVirtualInterfacesForDnsmasq:
+    def test_filter_raises_warns_and_returns_empty(self, mock_logger):
+        client = MagicMock()
+        client.api.dcim.interfaces.filter.side_effect = Exception("boom")
+
+        result = InterfaceHandler.get_virtual_interfaces_for_dnsmasq(
+            make_device(1, "d1"), client
+        )
+
+        assert result == []
+        mock_logger.warning.assert_called_once()
+
+    def test_no_interfaces_returns_empty(self):
+        assert _call([]) == []
+
+    def test_non_virtual_interface_skipped(self):
+        iface = _virtual(type=make_iface_type("1000base-t"))
+        assert _call([iface]) == []
+
+    def test_virtual_without_tags_skipped(self):
+        assert _call([_virtual(tags=())]) == []
+
+    def test_virtual_without_managed_tag_skipped(self):
+        assert _call([_virtual(tags=("other",))]) == []
+
+    def test_virtual_managed_without_untagged_vlan_skipped(self):
+        assert _call([_virtual(untagged_vlan=None)]) == []
+
+    def test_qualifying_interface_prefers_label_and_debug_logs_vid(self, mock_logger):
+        result = _call([_virtual(label="oob1", name="eth0")])
+
+        assert result == ["oob1"]
+        mock_logger.debug.assert_called_once()
+        message = mock_logger.debug.call_args.args[0]
+        assert "oob1" in message and "100" in message
+
+    def test_qualifying_interface_falls_back_to_name(self):
+        assert _call([_virtual(label=None, name="eth0")]) == ["eth0"]
+
+    def test_multiple_qualifying_interfaces_preserve_order(self):
+        iface1 = _virtual(id=1, label="oob1")
+        iface2 = _virtual(id=2, label="oob2")
+        assert _call([iface1, iface2]) == ["oob1", "oob2"]
+
+    def test_callable_as_static_method_without_instance(self):
+        # No InterfaceHandler() instance is constructed anywhere above.
+        assert _call([_virtual()]) == ["oob1"]

--- a/tests/unit/netbox/test_dnsmasq_manager.py
+++ b/tests/unit/netbox/test_dnsmasq_manager.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/dnsmasq/manager.py.
+
+``DnsmasqManager`` is a thin dispatcher: ``write_dnsmasq_config`` routes to the
+manager / readonly / metalbox handler depending on ``reconciler_mode`` (and
+whether ``all_devices`` is supplied), and ``write_dnsmasq_dhcp_ranges``
+delegates verbatim to the DHCP generator. The tests patch the instance
+collaborators with ``MagicMock``s and assert exactly one path runs per mode --
+no filesystem and no NetBox access are involved.
+"""
+
+from unittest.mock import MagicMock
+
+from dnsmasq.dhcp_config import DHCPConfigGenerator
+from dnsmasq.manager import DnsmasqManager
+from dnsmasq.manager_mode import ManagerModeHandler
+from dnsmasq.metalbox_mode import MetalboxModeHandler
+
+from .conftest import make_device, make_dnsmasq_config
+
+
+def _manager(tmp_path, monkeypatch, *, reconciler_mode="manager"):
+    mgr = DnsmasqManager(make_dnsmasq_config(tmp_path, reconciler_mode=reconciler_mode))
+    monkeypatch.setattr(mgr, "manager_handler", MagicMock())
+    monkeypatch.setattr(mgr, "metalbox_handler", MagicMock())
+    monkeypatch.setattr(mgr, "dhcp_generator", MagicMock())
+    return mgr
+
+
+DEVICES = [make_device(1, "node1")]
+ALL_DEVICES = [make_device(2, "node2")]
+
+
+class TestInit:
+    def test_constructs_collaborators(self, tmp_path):
+        mgr = DnsmasqManager(make_dnsmasq_config(tmp_path))
+        assert isinstance(mgr.dhcp_generator, DHCPConfigGenerator)
+        assert isinstance(mgr.manager_handler, ManagerModeHandler)
+        assert isinstance(mgr.metalbox_handler, MetalboxModeHandler)
+
+
+class TestWriteDnsmasqConfig:
+    def test_manager_readonly_calls_readonly_only(self, tmp_path, monkeypatch):
+        mgr = _manager(tmp_path, monkeypatch, reconciler_mode="manager-readonly")
+        client = MagicMock()
+
+        mgr.write_dnsmasq_config(client, DEVICES, all_devices=ALL_DEVICES)
+
+        mgr.manager_handler.process_devices_readonly.assert_called_once_with(DEVICES)
+        mgr.manager_handler.process_devices.assert_not_called()
+        mgr.metalbox_handler.process_devices.assert_not_called()
+        # Read-only path never touches the NetBox client.
+        client.get_device_oob_interface.assert_not_called()
+        client.update_device_custom_field.assert_not_called()
+
+    def test_metalbox_with_all_devices_calls_metalbox(self, tmp_path, monkeypatch):
+        mgr = _manager(tmp_path, monkeypatch, reconciler_mode="metalbox")
+        client = MagicMock()
+
+        mgr.write_dnsmasq_config(client, DEVICES, all_devices=ALL_DEVICES)
+
+        mgr.metalbox_handler.process_devices.assert_called_once_with(
+            client, DEVICES, ALL_DEVICES
+        )
+        mgr.manager_handler.process_devices.assert_not_called()
+        mgr.manager_handler.process_devices_readonly.assert_not_called()
+
+    def test_metalbox_without_all_devices_falls_through_to_manager(
+        self, tmp_path, monkeypatch
+    ):
+        mgr = _manager(tmp_path, monkeypatch, reconciler_mode="metalbox")
+        client = MagicMock()
+
+        mgr.write_dnsmasq_config(client, DEVICES, all_devices=None)
+
+        mgr.manager_handler.process_devices.assert_called_once_with(client, DEVICES)
+        mgr.metalbox_handler.process_devices.assert_not_called()
+
+    def test_metalbox_with_empty_all_devices_falls_through_to_manager(
+        self, tmp_path, monkeypatch
+    ):
+        mgr = _manager(tmp_path, monkeypatch, reconciler_mode="metalbox")
+        client = MagicMock()
+
+        mgr.write_dnsmasq_config(client, DEVICES, all_devices=[])
+
+        mgr.manager_handler.process_devices.assert_called_once_with(client, DEVICES)
+        mgr.metalbox_handler.process_devices.assert_not_called()
+
+    def test_manager_mode_calls_process_devices(self, tmp_path, monkeypatch):
+        mgr = _manager(tmp_path, monkeypatch, reconciler_mode="manager")
+        client = MagicMock()
+
+        mgr.write_dnsmasq_config(client, DEVICES)
+
+        mgr.manager_handler.process_devices.assert_called_once_with(client, DEVICES)
+        mgr.metalbox_handler.process_devices.assert_not_called()
+        mgr.manager_handler.process_devices_readonly.assert_not_called()
+
+
+class TestWriteDnsmasqDhcpRanges:
+    def test_delegates_without_prefix_tags(self, tmp_path, monkeypatch):
+        mgr = _manager(tmp_path, monkeypatch)
+        client = MagicMock()
+
+        mgr.write_dnsmasq_dhcp_ranges(client)
+
+        mgr.dhcp_generator.write_dhcp_ranges.assert_called_once_with(
+            client, prefix_tags=None
+        )
+
+    def test_delegates_with_prefix_tags(self, tmp_path, monkeypatch):
+        mgr = _manager(tmp_path, monkeypatch)
+        client = MagicMock()
+        prefix_tags = {"192.0.2.0/24": "oob"}
+
+        mgr.write_dnsmasq_dhcp_ranges(client, prefix_tags=prefix_tags)
+
+        mgr.dhcp_generator.write_dhcp_ranges.assert_called_once_with(
+            client, prefix_tags=prefix_tags
+        )

--- a/tests/unit/netbox/test_dnsmasq_manager_mode.py
+++ b/tests/unit/netbox/test_dnsmasq_manager_mode.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/dnsmasq/manager_mode.py.
+
+``ManagerModeHandler`` generates per-device dnsmasq host / MAC entries from the
+OOB interface (``process_devices``) or replays cached parameters from the
+device custom field (``process_devices_readonly``). The collaborator is a
+``MagicMock``-backed fake ``NetBoxClient`` whose ``get_device_oob_interface``
+and ``update_device_custom_field`` are stubbed per scenario;
+``write_dnsmasq_to_device`` (covered by the base tests) is replaced with a
+``MagicMock`` so the tests assert on the keys / call counts it receives. The
+module-level ``loguru`` logger is patched only where a log assertion documents
+the branch taken.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dnsmasq.manager_mode import ManagerModeHandler
+
+from .conftest import make_device, make_dnsmasq_config
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("dnsmasq.manager_mode.logger", logger)
+    return logger
+
+
+def _handler(tmp_path, monkeypatch):
+    """Build a ManagerModeHandler with write_dnsmasq_to_device mocked out."""
+    handler = ManagerModeHandler(make_dnsmasq_config(tmp_path))
+    monkeypatch.setattr(handler, "write_dnsmasq_to_device", MagicMock())
+    return handler
+
+
+def _client(oob, update_return=True):
+    client = MagicMock()
+    client.get_device_oob_interface.return_value = oob
+    client.update_device_custom_field.return_value = update_return
+    return client
+
+
+class TestProcessDevices:
+    def test_mac_and_ip_generates_host_and_mac_entries(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(1, "node1", device_type=SimpleNamespace(slug="server"))
+        client = _client(("192.0.2.10", "aa:bb:cc:dd:ee:ff", None))
+
+        handler.process_devices(client, [device])
+
+        client.update_device_custom_field.assert_called_once_with(
+            device,
+            "dnsmasq_parameters",
+            {
+                "dnsmasq_dhcp_hosts": ["aa:bb:cc:dd:ee:ff,node1,192.0.2.10"],
+                "dnsmasq_dhcp_macs": ["set:server,aa:bb:cc:dd:ee:ff"],
+            },
+        )
+        handler.write_dnsmasq_to_device.assert_called_once()
+        written = handler.write_dnsmasq_to_device.call_args.args[1]
+        assert written == {
+            "dnsmasq_dhcp_hosts__node1": ["aa:bb:cc:dd:ee:ff,node1,192.0.2.10"],
+            "dnsmasq_dhcp_macs__node1": ["set:server,aa:bb:cc:dd:ee:ff"],
+        }
+
+    def test_mac_without_ip_skips_host_entry(self, tmp_path, monkeypatch, mock_logger):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(1, "node1", device_type=SimpleNamespace(slug="server"))
+        client = _client((None, "aa:bb:cc:dd:ee:ff", None))
+
+        handler.process_devices(client, [device])
+
+        written = handler.write_dnsmasq_to_device.call_args.args[1]
+        assert "dnsmasq_dhcp_hosts__node1" not in written
+        assert written["dnsmasq_dhcp_macs__node1"] == ["set:server,aa:bb:cc:dd:ee:ff"]
+        # Cached host list stays empty when there is no IP.
+        params = client.update_device_custom_field.call_args.args[2]
+        assert params["dnsmasq_dhcp_hosts"] == []
+        assert any(
+            "no IP address" in call.args[0] for call in mock_logger.info.call_args_list
+        )
+
+    def test_no_mac_skips_device_entirely(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(1, "node1", device_type=SimpleNamespace(slug="server"))
+        client = _client((None, None, None))
+
+        handler.process_devices(client, [device])
+
+        client.update_device_custom_field.assert_not_called()
+        handler.write_dnsmasq_to_device.assert_not_called()
+
+    def test_no_tag_source_and_no_ip_caches_but_does_not_write(
+        self, tmp_path, monkeypatch
+    ):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(1, "node1")  # no device_type / tags / custom tag
+        client = _client((None, "aa:bb:cc:dd:ee:ff", None))
+
+        handler.process_devices(client, [device])
+
+        # Custom field still written (empty lists), but no file is written
+        # because dnsmasq_data ends up empty (the `if dnsmasq_data` guard).
+        client.update_device_custom_field.assert_called_once_with(
+            device,
+            "dnsmasq_parameters",
+            {"dnsmasq_dhcp_hosts": [], "dnsmasq_dhcp_macs": []},
+        )
+        handler.write_dnsmasq_to_device.assert_not_called()
+
+    def test_falsy_custom_field_update_warns(self, tmp_path, monkeypatch, mock_logger):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(1, "node1", device_type=SimpleNamespace(slug="server"))
+        client = _client(("192.0.2.10", "aa:bb:cc:dd:ee:ff", None), update_return=False)
+
+        handler.process_devices(client, [device])
+
+        mock_logger.warning.assert_called_once()
+
+
+class TestProcessDevicesReadonly:
+    def test_no_cached_params_skips(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+
+        handler.process_devices_readonly([make_device(1, "node1", custom_fields={})])
+
+        handler.write_dnsmasq_to_device.assert_not_called()
+
+    def test_none_custom_fields_skips(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = SimpleNamespace(name="node1", custom_fields=None)
+
+        handler.process_devices_readonly([device])
+
+        handler.write_dnsmasq_to_device.assert_not_called()
+
+    def test_cached_hosts_written(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(
+            1,
+            "node1",
+            custom_fields={"dnsmasq_parameters": {"dnsmasq_dhcp_hosts": ["h"]}},
+        )
+
+        handler.process_devices_readonly([device])
+
+        written = handler.write_dnsmasq_to_device.call_args.args[1]
+        assert written == {"dnsmasq_dhcp_hosts__node1": ["h"]}
+
+    def test_cached_macs_written(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(
+            1,
+            "node1",
+            custom_fields={"dnsmasq_parameters": {"dnsmasq_dhcp_macs": ["m"]}},
+        )
+
+        handler.process_devices_readonly([device])
+
+        written = handler.write_dnsmasq_to_device.call_args.args[1]
+        assert written == {"dnsmasq_dhcp_macs__node1": ["m"]}
+
+    def test_cached_hosts_and_macs_written(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(
+            1,
+            "node1",
+            custom_fields={
+                "dnsmasq_parameters": {
+                    "dnsmasq_dhcp_hosts": ["h"],
+                    "dnsmasq_dhcp_macs": ["m"],
+                }
+            },
+        )
+
+        handler.process_devices_readonly([device])
+
+        written = handler.write_dnsmasq_to_device.call_args.args[1]
+        assert written == {
+            "dnsmasq_dhcp_hosts__node1": ["h"],
+            "dnsmasq_dhcp_macs__node1": ["m"],
+        }
+
+    def test_cached_empty_lists_no_write(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, monkeypatch)
+        device = make_device(
+            1,
+            "node1",
+            custom_fields={
+                "dnsmasq_parameters": {
+                    "dnsmasq_dhcp_hosts": [],
+                    "dnsmasq_dhcp_macs": [],
+                }
+            },
+        )
+
+        handler.process_devices_readonly([device])
+
+        handler.write_dnsmasq_to_device.assert_not_called()

--- a/tests/unit/netbox/test_dnsmasq_metalbox_mode.py
+++ b/tests/unit/netbox/test_dnsmasq_metalbox_mode.py
@@ -23,6 +23,7 @@ matters; the higher-level ``netbox_client`` façade methods
 """
 
 import ipaddress
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,7 +40,9 @@ from .conftest import (
     make_interface,
     make_ip,
     make_prefix,
+    make_tag,
     make_vlan,
+    make_vlan_group,
 )
 
 
@@ -400,3 +403,646 @@ class TestGetDynamicHostsRouted:
             "metalbox,192.0.2.254,oob0",
             "metalbox.osism.xyz,192.0.2.254,oob0",
         ]
+
+
+# ===========================================================================
+# Part 2 -- collectors & process_devices
+# ===========================================================================
+
+
+class TestGetDynamicHostsForMetalbox:
+    def test_no_oob_networks_returns_empty(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([])
+        client.get_oob_networks.return_value = []
+        assert handler.get_dynamic_hosts_for_metalbox(make_device(1, "m"), client) == []
+
+    def test_filter_raises_warns_and_returns_empty(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        client = MagicMock()
+        client.get_oob_networks.return_value = [
+            make_prefix("192.0.2.0/24", vlan=make_vlan(100))
+        ]
+        client.api.dcim.interfaces.filter.side_effect = Exception("boom")
+
+        assert handler.get_dynamic_hosts_for_metalbox(make_device(1, "m"), client) == []
+        mock_logger.warning.assert_called_once()
+
+    def test_matching_network_and_interface_emits_both_entries(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1, name="oob0", label="oob-vlan", untagged_vlan=make_vlan(100)
+        )
+        client = _client([iface], {1: [make_ip("192.0.2.10/24")]})
+        client.get_oob_networks.return_value = [
+            make_prefix("192.0.2.0/24", vlan=make_vlan(100))
+        ]
+
+        result = handler.get_dynamic_hosts_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        assert result == [
+            "metalbox,192.0.2.10,oob-vlan",
+            "metalbox.osism.xyz,192.0.2.10,oob-vlan",
+        ]
+
+    def test_breaks_on_first_matching_ip(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1, name="oob0", label="oob-vlan", untagged_vlan=make_vlan(100)
+        )
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.10/24"), make_ip("192.0.2.11/24")]},
+        )
+        client.get_oob_networks.return_value = [
+            make_prefix("192.0.2.0/24", vlan=make_vlan(100))
+        ]
+
+        result = handler.get_dynamic_hosts_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        assert result == [
+            "metalbox,192.0.2.10,oob-vlan",
+            "metalbox.osism.xyz,192.0.2.10,oob-vlan",
+        ]
+
+    def test_network_without_vlan_contributes_nothing(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(id=1, label="oob-vlan", untagged_vlan=make_vlan(100))
+        client = _client([iface], {1: [make_ip("192.0.2.10/24")]})
+        client.get_oob_networks.return_value = [make_prefix("192.0.2.0/24")]
+
+        assert handler.get_dynamic_hosts_for_metalbox(make_device(2, "m"), client) == []
+
+    def test_vlan_without_matching_interface_contributes_nothing(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(id=1, label="oob-vlan", untagged_vlan=make_vlan(100))
+        client = _client([iface], {1: [make_ip("192.0.2.10/24")]})
+        client.get_oob_networks.return_value = [
+            make_prefix("192.0.2.0/24", vlan=make_vlan(200))
+        ]
+
+        assert handler.get_dynamic_hosts_for_metalbox(make_device(2, "m"), client) == []
+
+
+class TestGetDhcpOptionsForMetalbox:
+    def test_filter_raises_warns_and_returns_empty(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        client = MagicMock()
+        client.api.dcim.interfaces.filter.side_effect = Exception("boom")
+
+        assert handler.get_dhcp_options_for_metalbox(make_device(1, "m"), client) == []
+        mock_logger.warning.assert_called_once()
+
+    def test_managed_vlan_emits_dns_and_ntp_options(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1, name="oob0", tags=("managed-by-osism",), untagged_vlan=make_vlan(100)
+        )
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.10/24")]},
+            prefixes=[make_prefix("192.0.2.0/24", vlan=make_vlan(100))],
+        )
+
+        result = handler.get_dhcp_options_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        assert result == [
+            "tag:vlan100,6,192.0.2.10",
+            "tag:vlan100,42,192.0.2.10",
+        ]
+
+    def test_vlan_not_in_managed_set_is_skipped(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1, name="oob0", tags=("managed-by-osism",), untagged_vlan=make_vlan(200)
+        )
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.10/24")]},
+            prefixes=[make_prefix("192.0.2.0/24", vlan=make_vlan(100))],
+        )
+
+        assert handler.get_dhcp_options_for_metalbox(make_device(2, "m"), client) == []
+
+    def test_prefixes_filter_raises_disables_managed_filter(
+        self, tmp_path, mock_logger
+    ):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1, name="oob0", tags=("managed-by-osism",), untagged_vlan=make_vlan(100)
+        )
+        client = MagicMock()
+        client.api.dcim.interfaces.filter.return_value = [iface]
+        client.api.ipam.prefixes.filter.side_effect = Exception("boom")
+        client.api.ipam.ip_addresses.filter.return_value = [make_ip("192.0.2.10/24")]
+
+        result = handler.get_dhcp_options_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        # managed_vlan_ids falls back to None, so the VLAN filter is disabled.
+        assert result == [
+            "tag:vlan100,6,192.0.2.10",
+            "tag:vlan100,42,192.0.2.10",
+        ]
+        mock_logger.warning.assert_called_once()
+
+    def test_routed_vlan_group_adds_gateway_option(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1,
+            name="oob0",
+            tags=("managed-by-osism",),
+            untagged_vlan=make_vlan(100, group=make_vlan_group("routed-oob")),
+        )
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.10/24")]},
+            prefixes=[make_prefix("192.0.2.0/24", vlan=make_vlan(100))],
+        )
+
+        result = handler.get_dhcp_options_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        assert result == [
+            "tag:vlan100,6,192.0.2.10",
+            "tag:vlan100,42,192.0.2.10",
+            "tag:vlan100,3,192.0.2.1",
+        ]
+
+    def test_only_first_ip_per_interface_is_used(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1, name="oob0", tags=("managed-by-osism",), untagged_vlan=make_vlan(100)
+        )
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.10/24"), make_ip("192.0.2.11/24")]},
+            prefixes=[make_prefix("192.0.2.0/24", vlan=make_vlan(100))],
+        )
+
+        result = handler.get_dhcp_options_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        assert result == [
+            "tag:vlan100,6,192.0.2.10",
+            "tag:vlan100,42,192.0.2.10",
+        ]
+
+    def test_gateway_calc_exception_warns(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        iface = _virtual(
+            id=1,
+            name="oob0",
+            tags=("managed-by-osism",),
+            untagged_vlan=make_vlan(100, group=make_vlan_group("routed")),
+        )
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.999/24")]},  # malformed -> gateway calc raises
+            prefixes=[make_prefix("192.0.2.0/24", vlan=make_vlan(100))],
+        )
+
+        result = handler.get_dhcp_options_for_metalbox(
+            make_device(2, "metalbox"), client
+        )
+
+        # 6 and 42 still emitted from the raw string; the gateway option is not.
+        assert result == [
+            "tag:vlan100,6,192.0.2.999",
+            "tag:vlan100,42,192.0.2.999",
+        ]
+        mock_logger.warning.assert_called_once()
+
+    def test_no_interfaces_returns_empty(self, tmp_path):
+        handler = _handler(tmp_path)
+        assert (
+            handler.get_dhcp_options_for_metalbox(make_device(1, "m"), _client([]))
+            == []
+        )
+
+    @pytest.mark.parametrize(
+        "iface",
+        [
+            # non-virtual
+            _virtual(
+                id=1,
+                type=make_iface_type("1000base-t"),
+                tags=("managed-by-osism",),
+                untagged_vlan=make_vlan(100),
+            ),
+            # no tags
+            _virtual(id=1, tags=(), untagged_vlan=make_vlan(100)),
+            # tags without managed-by-osism
+            _virtual(id=1, tags=("other",), untagged_vlan=make_vlan(100)),
+            # no untagged VLAN
+            _virtual(id=1, tags=("managed-by-osism",), untagged_vlan=None),
+        ],
+    )
+    def test_non_qualifying_interfaces_skipped(self, tmp_path, iface):
+        handler = _handler(tmp_path)
+        client = _client(
+            [iface],
+            {1: [make_ip("192.0.2.10/24")]},
+            prefixes=[make_prefix("192.0.2.0/24", vlan=make_vlan(100))],
+        )
+        assert handler.get_dhcp_options_for_metalbox(make_device(2, "m"), client) == []
+
+
+def _oob(mapping):
+    """A get_device_oob_interface side_effect keyed by device.id."""
+    return lambda device: mapping[device.id]
+
+
+class TestProcessDevices:
+    def test_no_metalbox_device_early_returns(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", MagicMock())
+        client = MagicMock()
+        devices = [make_device(1, "node1", role=make_tag("compute"))]
+
+        handler.process_devices(client, devices, devices)
+
+        handler.write_dnsmasq_to_device.assert_not_called()
+        client.get_device_oob_interface.assert_not_called()
+
+    def test_bridged_writes_five_metalbox_keys(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        write = MagicMock()
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", write)
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=["vlan100"]),
+        )
+        dyn = MagicMock(return_value=["metalbox,192.0.2.1,vlan100"])
+        opts = MagicMock(return_value=["tag:vlan100,6,192.0.2.1"])
+        monkeypatch.setattr(handler, "get_dynamic_hosts_for_metalbox", dyn)
+        monkeypatch.setattr(handler, "get_dhcp_options_for_metalbox", opts)
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        node = make_device(
+            2,
+            "node1",
+            role=make_tag("compute"),
+            device_type=SimpleNamespace(slug="server"),
+        )
+        client = MagicMock()
+        client.get_device_oob_interface.side_effect = _oob(
+            {
+                1: ("192.0.2.1", "aa:aa:aa:aa:aa:aa", None),
+                2: ("192.0.2.10", "bb:bb:bb:bb:bb:bb", None),
+            }
+        )
+        client.update_device_custom_field.return_value = True
+
+        handler.process_devices(client, [metalbox], [metalbox, node])
+
+        write.assert_called_once()
+        written = write.call_args.args[1]
+        assert set(written) == {
+            "dnsmasq_dhcp_hosts__metalbox",
+            "dnsmasq_dhcp_macs__metalbox",
+            "dnsmasq_interfaces__metalbox",
+            "dnsmasq_dynamic_hosts__metalbox",
+            "dnsmasq_dhcp_options__metalbox",
+        }
+        assert written["dnsmasq_dhcp_hosts__metalbox"] == [
+            "aa:aa:aa:aa:aa:aa,metalbox,192.0.2.1",
+            "bb:bb:bb:bb:bb:bb,node1,192.0.2.10",
+        ]
+        assert written["dnsmasq_dhcp_macs__metalbox"] == [
+            "set:metal,aa:aa:aa:aa:aa:aa",
+            "set:server,bb:bb:bb:bb:bb:bb",
+        ]
+        assert written["dnsmasq_interfaces__metalbox"] == ["vlan100"]
+        assert written["dnsmasq_dynamic_hosts__metalbox"] == [
+            "metalbox,192.0.2.1,vlan100"
+        ]
+        assert written["dnsmasq_dhcp_options__metalbox"] == ["tag:vlan100,6,192.0.2.1"]
+        dyn.assert_called_once()
+        opts.assert_called_once()
+
+    def test_bridged_deduplicates_by_hostname_and_mac(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        write = MagicMock()
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", write)
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=["vlan100"]),
+        )
+        monkeypatch.setattr(
+            handler, "get_dynamic_hosts_for_metalbox", MagicMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            handler, "get_dhcp_options_for_metalbox", MagicMock(return_value=[])
+        )
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        # Two devices that resolve to the same hostname and MAC -> collapse.
+        dup_a = make_device(
+            2,
+            "dup",
+            role=make_tag("compute"),
+            device_type=SimpleNamespace(slug="server"),
+        )
+        dup_b = make_device(
+            3,
+            "raw",
+            role=make_tag("compute"),
+            device_type=SimpleNamespace(slug="server"),
+            custom_fields={"inventory_hostname": "dup"},
+        )
+        client = MagicMock()
+        client.get_device_oob_interface.side_effect = _oob(
+            {
+                1: ("192.0.2.1", "aa:aa:aa:aa:aa:aa", None),
+                2: ("192.0.2.10", "bb:bb:bb:bb:bb:bb", None),
+                3: ("192.0.2.10", "bb:bb:bb:bb:bb:bb", None),
+            }
+        )
+        client.update_device_custom_field.return_value = True
+
+        handler.process_devices(client, [metalbox], [metalbox, dup_a, dup_b])
+
+        written = write.call_args.args[1]
+        # Metalbox + the single deduped "dup" host / MAC.
+        assert written["dnsmasq_dhcp_hosts__metalbox"] == [
+            "aa:aa:aa:aa:aa:aa,metalbox,192.0.2.1",
+            "bb:bb:bb:bb:bb:bb,dup,192.0.2.10",
+        ]
+        assert written["dnsmasq_dhcp_macs__metalbox"] == [
+            "set:metal,aa:aa:aa:aa:aa:aa",
+            "set:server,bb:bb:bb:bb:bb:bb",
+        ]
+
+    def test_routed_uses_routed_helpers_and_set_tags(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        write = MagicMock()
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", write)
+        # No VLAN interfaces on the metalbox -> routed mode.
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            handler,
+            "_get_metalbox_oob_virtual_interface",
+            MagicMock(return_value=("192.0.2.254", "oob0")),
+        )
+        monkeypatch.setattr(
+            handler,
+            "_get_physical_uplink_interfaces",
+            MagicMock(return_value=["uplink0"]),
+        )
+        bridged_dyn = MagicMock(return_value=["should-not-be-used"])
+        bridged_opts = MagicMock(return_value=["should-not-be-used"])
+        monkeypatch.setattr(handler, "get_dynamic_hosts_for_metalbox", bridged_dyn)
+        monkeypatch.setattr(handler, "get_dhcp_options_for_metalbox", bridged_opts)
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        node = make_device(
+            2,
+            "node1",
+            role=make_tag("compute"),
+            device_type=SimpleNamespace(slug="server"),
+        )
+        client = MagicMock()
+        client.get_oob_networks.return_value = [
+            make_prefix("192.0.2.0/24", vlan=make_vlan(100))
+        ]
+        client.get_device_oob_interface.side_effect = _oob(
+            {
+                1: ("192.0.2.254", "aa:aa:aa:aa:aa:aa", None),
+                2: ("192.0.2.10", "bb:bb:bb:bb:bb:bb", None),
+            }
+        )
+        client.update_device_custom_field.return_value = True
+
+        handler.process_devices(client, [metalbox], [metalbox, node])
+
+        written = write.call_args.args[1]
+        # set_tag derived from the prefix mapping (vlan100) is appended to hosts.
+        assert written["dnsmasq_dhcp_hosts__metalbox"] == [
+            "aa:aa:aa:aa:aa:aa,metalbox,192.0.2.254,set:vlan100",
+            "bb:bb:bb:bb:bb:bb,node1,192.0.2.10,set:vlan100",
+        ]
+        # Routed helpers drive interfaces / dynamic hosts / options.
+        assert written["dnsmasq_interfaces__metalbox"] == ["oob0", "uplink0"]
+        assert written["dnsmasq_dynamic_hosts__metalbox"] == [
+            "metalbox,192.0.2.254,oob0",
+            "metalbox.osism.xyz,192.0.2.254,oob0",
+        ]
+        assert written["dnsmasq_dhcp_options__metalbox"] == [
+            "tag:vlan100,3,192.0.2.1",
+            "tag:vlan100,6,192.0.2.254",
+            "tag:vlan100,42,192.0.2.254",
+        ]
+        bridged_dyn.assert_not_called()
+        bridged_opts.assert_not_called()
+
+    def test_switch_tracking_excludes_metalbox_own_params(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        write = MagicMock()
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", write)
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=["vlan100"]),
+        )
+        monkeypatch.setattr(
+            handler, "get_dynamic_hosts_for_metalbox", MagicMock(return_value=["dh"])
+        )
+        monkeypatch.setattr(
+            handler, "get_dhcp_options_for_metalbox", MagicMock(return_value=["do"])
+        )
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        leaf = make_device(
+            2,
+            "leaf1",
+            role=make_tag("leaf"),
+            device_type=SimpleNamespace(slug="switch"),
+        )
+        client = MagicMock()
+        client.get_device_oob_interface.side_effect = _oob(
+            {
+                1: ("192.0.2.1", "aa:aa:aa:aa:aa:aa", None),
+                2: ("192.0.2.2", "bb:bb:bb:bb:bb:bb", None),
+            }
+        )
+        client.update_device_custom_field.return_value = True
+
+        handler.process_devices(client, [metalbox], [metalbox, leaf])
+
+        # Final custom-field write caches only the switch params on the metalbox.
+        last_call = client.update_device_custom_field.call_args_list[-1]
+        assert last_call.args[0] is metalbox
+        cached = last_call.args[2]
+        assert cached["dnsmasq_dhcp_hosts"] == ["bb:bb:bb:bb:bb:bb,leaf1,192.0.2.2"]
+        assert cached["dnsmasq_dhcp_macs"] == ["set:switch,bb:bb:bb:bb:bb:bb"]
+        assert (
+            "aa:aa:aa:aa:aa:aa,metalbox,192.0.2.1" not in cached["dnsmasq_dhcp_hosts"]
+        )
+        # The written file still carries both metalbox and switch host entries.
+        written = write.call_args.args[1]
+        assert (
+            "aa:aa:aa:aa:aa:aa,metalbox,192.0.2.1"
+            in written["dnsmasq_dhcp_hosts__metalbox"]
+        )
+        assert (
+            "bb:bb:bb:bb:bb:bb,leaf1,192.0.2.2"
+            in written["dnsmasq_dhcp_hosts__metalbox"]
+        )
+
+    def test_mac_without_ip_contributes_mac_entry_only(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        write = MagicMock()
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", write)
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=["vlan100"]),
+        )
+        monkeypatch.setattr(
+            handler, "get_dynamic_hosts_for_metalbox", MagicMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            handler, "get_dhcp_options_for_metalbox", MagicMock(return_value=[])
+        )
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        node = make_device(
+            2,
+            "node1",
+            role=make_tag("compute"),
+            device_type=SimpleNamespace(slug="server"),
+        )
+        client = MagicMock()
+        client.get_device_oob_interface.side_effect = _oob(
+            {
+                1: ("192.0.2.1", "aa:aa:aa:aa:aa:aa", None),
+                2: (None, "bb:bb:bb:bb:bb:bb", None),  # MAC but no IP
+            }
+        )
+        client.update_device_custom_field.return_value = True
+
+        handler.process_devices(client, [metalbox], [metalbox, node])
+
+        written = write.call_args.args[1]
+        assert written["dnsmasq_dhcp_hosts__metalbox"] == [
+            "aa:aa:aa:aa:aa:aa,metalbox,192.0.2.1"
+        ]
+        assert "set:server,bb:bb:bb:bb:bb:bb" in written["dnsmasq_dhcp_macs__metalbox"]
+
+    def test_non_mac_metalbox_caches_virtual_interfaces(self, tmp_path, monkeypatch):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        write = MagicMock()
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", write)
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=["vlan100"]),
+        )
+        monkeypatch.setattr(
+            handler, "get_dynamic_hosts_for_metalbox", MagicMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            handler, "get_dhcp_options_for_metalbox", MagicMock(return_value=[])
+        )
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        client = MagicMock()
+        client.get_device_oob_interface.side_effect = _oob({1: (None, None, None)})
+        client.update_device_custom_field.return_value = True
+
+        handler.process_devices(client, [metalbox], [metalbox])
+
+        # Line-730 path: the metalbox's virtual interfaces are cached even
+        # though it has no OOB MAC.
+        client.update_device_custom_field.assert_called_once_with(
+            metalbox,
+            "dnsmasq_parameters",
+            {
+                "dnsmasq_dhcp_hosts": [],
+                "dnsmasq_dhcp_macs": [],
+                "dnsmasq_interfaces": ["vlan100"],
+            },
+        )
+        written = write.call_args.args[1]
+        assert written["dnsmasq_interfaces__metalbox"] == ["vlan100"]
+        assert written["dnsmasq_dhcp_hosts__metalbox"] == []
+
+    def test_falsy_custom_field_update_warns(self, tmp_path, monkeypatch, mock_logger):
+        handler = _handler(tmp_path, reconciler_mode="metalbox")
+        monkeypatch.setattr(handler, "write_dnsmasq_to_device", MagicMock())
+        monkeypatch.setattr(
+            handler.interface_handler,
+            "get_virtual_interfaces_for_dnsmasq",
+            MagicMock(return_value=["vlan100"]),
+        )
+        monkeypatch.setattr(
+            handler, "get_dynamic_hosts_for_metalbox", MagicMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            handler, "get_dhcp_options_for_metalbox", MagicMock(return_value=[])
+        )
+
+        metalbox = make_device(
+            1,
+            "metalbox",
+            role=make_tag("metalbox"),
+            device_type=SimpleNamespace(slug="metal"),
+        )
+        client = MagicMock()
+        client.get_device_oob_interface.side_effect = _oob(
+            {1: ("192.0.2.1", "aa:aa:aa:aa:aa:aa", None)}
+        )
+        client.update_device_custom_field.return_value = False
+
+        handler.process_devices(client, [metalbox], [metalbox])
+
+        assert any(
+            "Failed to cache" in call.args[0]
+            for call in mock_logger.warning.call_args_list
+        )

--- a/tests/unit/netbox/test_dnsmasq_metalbox_mode.py
+++ b/tests/unit/netbox/test_dnsmasq_metalbox_mode.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for files/netbox/dnsmasq/metalbox_mode.py.
+
+``MetalboxModeHandler`` builds the metalbox OOB dnsmasq configuration in two
+sub-modes (bridged / routed). This file covers, in two parts:
+
+* Part 1 -- the pure and single-interface helpers (``_build_prefix_tag_mapping``,
+  ``_index_to_suffix``, ``_get_set_tag_for_ip``,
+  ``_get_metalbox_oob_virtual_interface``, ``_get_ipv4_from_interface``,
+  ``_get_physical_uplink_interfaces``, ``_get_dhcp_options_routed``,
+  ``_get_dynamic_hosts_routed``).
+* Part 2 -- the collectors (``get_dynamic_hosts_for_metalbox``,
+  ``get_dhcp_options_for_metalbox``) and the ``process_devices`` orchestrator
+  (bridged / routed / switch-tracking scenarios).
+
+Interfaces / IP addresses / prefixes are read through a pynetbox session faked
+by ``make_fake_api`` (plain lists) or a ``MagicMock`` where ``side_effect``
+matters; the higher-level ``netbox_client`` façade methods
+(``get_oob_networks``, ``get_all_oob_prefixes``, ``get_device_oob_interface``,
+``update_device_custom_field``) are stubbed per scenario. The module-level
+``loguru`` logger is patched only where a log assertion documents the branch.
+"""
+
+import ipaddress
+from unittest.mock import MagicMock
+
+import pytest
+
+from dnsmasq.dhcp_config import DHCPConfigGenerator
+from dnsmasq.interface_handler import InterfaceHandler
+from dnsmasq.metalbox_mode import MetalboxModeHandler
+
+from .conftest import (
+    make_device,
+    make_dnsmasq_config,
+    make_fake_api,
+    make_iface_type,
+    make_interface,
+    make_ip,
+    make_prefix,
+    make_vlan,
+)
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """Replace the module-level loguru logger with a MagicMock."""
+    logger = MagicMock()
+    monkeypatch.setattr("dnsmasq.metalbox_mode.logger", logger)
+    return logger
+
+
+def _handler(tmp_path, **overrides):
+    return MetalboxModeHandler(make_dnsmasq_config(tmp_path, **overrides))
+
+
+def _client(interfaces=(), ips_by_interface=None, *, oob_prefixes=(), prefixes=()):
+    """Fake NetBoxClient: a MagicMock with a make_fake_api .api."""
+    client = MagicMock()
+    client.api = make_fake_api(
+        interfaces=interfaces,
+        ips_by_interface=ips_by_interface or {},
+        prefixes=prefixes,
+    )
+    client.get_all_oob_prefixes.return_value = list(oob_prefixes)
+    return client
+
+
+def _virtual(**overrides):
+    params = dict(type=make_iface_type("virtual"))
+    params.update(overrides)
+    return make_interface(**params)
+
+
+# ===========================================================================
+# Part 1 -- pure & single-interface helpers
+# ===========================================================================
+
+
+class TestInit:
+    def test_constructs_collaborators(self, tmp_path):
+        config = make_dnsmasq_config(tmp_path)
+        handler = MetalboxModeHandler(config)
+        assert handler.config is config
+        assert isinstance(handler.dhcp_generator, DHCPConfigGenerator)
+        assert isinstance(handler.interface_handler, InterfaceHandler)
+
+
+class TestBuildPrefixTagMapping:
+    def test_ipv6_prefixes_dropped(self, tmp_path):
+        handler = _handler(tmp_path)
+        mapping = handler._build_prefix_tag_mapping(
+            [
+                make_prefix("192.0.2.0/24", vlan=make_vlan(100)),
+                make_prefix("2001:db8::/64", vlan=make_vlan(200)),
+            ]
+        )
+        assert "2001:db8::/64" not in mapping
+        assert mapping["192.0.2.0/24"]["tag"] == "vlan100"
+
+    def test_unique_vlan_and_no_vlan_tags(self, tmp_path):
+        handler = _handler(tmp_path)
+        mapping = handler._build_prefix_tag_mapping(
+            [
+                make_prefix("192.0.2.0/24", vlan=make_vlan(100)),
+                make_prefix("198.51.100.0/24"),
+            ]
+        )
+        assert mapping["192.0.2.0/24"]["tag"] == "vlan100"
+        assert mapping["198.51.100.0/24"]["tag"] == "oob"
+
+    def test_duplicate_vlan_ids_get_sorted_suffixes(self, tmp_path):
+        handler = _handler(tmp_path)
+        mapping = handler._build_prefix_tag_mapping(
+            [
+                make_prefix("198.51.100.0/24", vlan=make_vlan(100)),
+                make_prefix("192.0.2.0/24", vlan=make_vlan(100)),
+            ]
+        )
+        # Suffixes follow network-address order, independent of input order.
+        assert mapping["192.0.2.0/24"]["tag"] == "vlan100a"
+        assert mapping["198.51.100.0/24"]["tag"] == "vlan100b"
+
+    def test_duplicate_no_vlan_prefixes_get_oob_suffixes(self, tmp_path):
+        handler = _handler(tmp_path)
+        mapping = handler._build_prefix_tag_mapping(
+            [make_prefix("198.51.100.0/24"), make_prefix("192.0.2.0/24")]
+        )
+        assert mapping["192.0.2.0/24"]["tag"] == "ooba"
+        assert mapping["198.51.100.0/24"]["tag"] == "oobb"
+
+    def test_suffix_assignment_is_deterministic_under_shuffle(self, tmp_path):
+        handler = _handler(tmp_path)
+        prefixes = [
+            make_prefix("203.0.113.0/24", vlan=make_vlan(100)),
+            make_prefix("192.0.2.0/24", vlan=make_vlan(100)),
+            make_prefix("198.51.100.0/24", vlan=make_vlan(100)),
+        ]
+        mapping = handler._build_prefix_tag_mapping(prefixes)
+        assert mapping["192.0.2.0/24"]["tag"] == "vlan100a"
+        assert mapping["198.51.100.0/24"]["tag"] == "vlan100b"
+        assert mapping["203.0.113.0/24"]["tag"] == "vlan100c"
+
+    def test_return_shape(self, tmp_path):
+        handler = _handler(tmp_path)
+        mapping = handler._build_prefix_tag_mapping(
+            [make_prefix("192.0.2.0/24", vlan=make_vlan(100))]
+        )
+        assert mapping["192.0.2.0/24"] == {
+            "tag": "vlan100",
+            "network": ipaddress.ip_network("192.0.2.0/24"),
+            "vlan_id": 100,
+        }
+
+
+class TestIndexToSuffix:
+    @pytest.mark.parametrize(
+        "idx,expected",
+        [
+            (0, "a"),
+            (25, "z"),
+            (26, "aa"),
+            (27, "ab"),
+            (51, "az"),
+            (52, "ba"),
+            (701, "zz"),
+        ],
+    )
+    def test_index_to_suffix(self, idx, expected):
+        assert MetalboxModeHandler._index_to_suffix(idx) == expected
+
+
+class TestGetSetTagForIp:
+    def _mapping(self, tmp_path):
+        return _handler(tmp_path)._build_prefix_tag_mapping(
+            [make_prefix("192.0.2.0/24", vlan=make_vlan(100))]
+        )
+
+    def test_ip_inside_mapped_network(self, tmp_path):
+        handler = _handler(tmp_path)
+        assert (
+            handler._get_set_tag_for_ip("192.0.2.10", self._mapping(tmp_path))
+            == "vlan100"
+        )
+
+    def test_ip_outside_all_networks(self, tmp_path):
+        handler = _handler(tmp_path)
+        assert handler._get_set_tag_for_ip("10.0.0.1", self._mapping(tmp_path)) is None
+
+    def test_ip_with_prefix_suffix_is_stripped(self, tmp_path):
+        handler = _handler(tmp_path)
+        assert (
+            handler._get_set_tag_for_ip("192.0.2.10/24", self._mapping(tmp_path))
+            == "vlan100"
+        )
+
+
+class TestGetMetalboxOobVirtualInterface:
+    def test_priority1_loopback0_with_ipv4(self, tmp_path):
+        handler = _handler(tmp_path)
+        lb = make_interface(id=1, name="loopback0", type=make_iface_type("virtual"))
+        client = _client([lb], {1: [make_ip("192.0.2.5/24")]})
+
+        result = handler._get_metalbox_oob_virtual_interface(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == ("192.0.2.5", "loopback0")
+
+    def test_priority2_single_virtual_prefers_label(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        v = _virtual(id=2, name="oob0", label="oob-label")
+        client = _client([v], {2: [make_ip("192.0.2.6/24")]})
+
+        result = handler._get_metalbox_oob_virtual_interface(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == ("192.0.2.6", "oob-label")
+        mock_logger.info.assert_called_once()
+
+    def test_priority3_out_of_band_tagged_interface(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        v1 = _virtual(id=3, name="v1", tags=())
+        v2 = _virtual(id=4, name="v2", label="oob2", tags=("out-of-band",))
+        client = _client([v1, v2], {4: [make_ip("192.0.2.7/24")]})
+
+        result = handler._get_metalbox_oob_virtual_interface(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == ("192.0.2.7", "oob2")
+        mock_logger.info.assert_called_once()
+
+    def test_multiple_virtual_none_out_of_band_warns(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        v1 = _virtual(id=3, name="v1", tags=())
+        v2 = _virtual(id=4, name="v2", tags=("other",))
+        client = _client([v1, v2])
+
+        result = handler._get_metalbox_oob_virtual_interface(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == (None, None)
+        mock_logger.warning.assert_called_once()
+
+    def test_loopback0_without_ipv4_falls_through(self, tmp_path):
+        handler = _handler(tmp_path)
+        # loopback0 is non-virtual and has no IP -> P1 misses, falls to P2.
+        lb = make_interface(id=1, name="loopback0", type=make_iface_type("1000base-t"))
+        v = _virtual(id=2, name="oob0", label="oob-label")
+        client = _client([lb, v], {2: [make_ip("192.0.2.8/24")]})
+
+        result = handler._get_metalbox_oob_virtual_interface(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == ("192.0.2.8", "oob-label")
+
+    def test_nothing_resolvable(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([])
+
+        result = handler._get_metalbox_oob_virtual_interface(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == (None, None)
+
+
+class TestGetIpv4FromInterface:
+    def test_single_ipv4_returned_without_prefix(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = make_interface(id=5)
+        client = _client([], {5: [make_ip("192.0.2.7/24")]})
+        assert handler._get_ipv4_from_interface(iface, client) == "192.0.2.7"
+
+    def test_only_ipv6_returns_none(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = make_interface(id=5)
+        client = _client([], {5: [make_ip("2001:db8::1/64")]})
+        assert handler._get_ipv4_from_interface(iface, client) is None
+
+    def test_no_addresses_returns_none(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = make_interface(id=5)
+        client = _client([], {5: []})
+        assert handler._get_ipv4_from_interface(iface, client) is None
+
+    def test_multiple_ipv4_prefers_oob_role_prefix(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = make_interface(id=5)
+        client = _client(
+            [],
+            {5: [make_ip("10.0.0.1/24"), make_ip("192.0.2.8/24")]},
+            oob_prefixes=[make_prefix("192.0.2.0/24")],
+        )
+        assert handler._get_ipv4_from_interface(iface, client) == "192.0.2.8"
+
+    def test_multiple_ipv4_none_in_oob_prefix_falls_back_to_first(self, tmp_path):
+        handler = _handler(tmp_path)
+        iface = make_interface(id=5)
+        client = _client(
+            [],
+            {5: [make_ip("10.0.0.1/24"), make_ip("192.0.2.8/24")]},
+            oob_prefixes=[make_prefix("203.0.113.0/24")],
+        )
+        assert handler._get_ipv4_from_interface(iface, client) == "10.0.0.1"
+
+
+class TestGetPhysicalUplinkInterfaces:
+    def _uplink(self, **overrides):
+        params = dict(
+            id=1,
+            tags=("managed-by-osism", "out-of-band"),
+            label="up0",
+            connected_endpoints=[object()],
+            enabled=True,
+            mgmt_only=False,
+        )
+        params.update(overrides)
+        return make_interface(**params)
+
+    def test_qualifying_interface_label_collected(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([self._uplink()])
+        result = handler._get_physical_uplink_interfaces(
+            make_device(1, "metalbox"), client
+        )
+        assert result == ["up0"]
+
+    def test_missing_required_tag_skipped(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([self._uplink(tags=("managed-by-osism",))])
+        assert (
+            handler._get_physical_uplink_interfaces(make_device(1, "m"), client) == []
+        )
+
+    def test_missing_label_skipped(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([self._uplink(label=None)])
+        assert (
+            handler._get_physical_uplink_interfaces(make_device(1, "m"), client) == []
+        )
+
+    def test_no_connected_endpoints_skipped(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([self._uplink(connected_endpoints=None)])
+        assert (
+            handler._get_physical_uplink_interfaces(make_device(1, "m"), client) == []
+        )
+
+    def test_disabled_skipped(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([self._uplink(enabled=False)])
+        assert (
+            handler._get_physical_uplink_interfaces(make_device(1, "m"), client) == []
+        )
+
+    def test_mgmt_only_skipped(self, tmp_path):
+        handler = _handler(tmp_path)
+        client = _client([self._uplink(mgmt_only=True)])
+        assert (
+            handler._get_physical_uplink_interfaces(make_device(1, "m"), client) == []
+        )
+
+    def test_filter_raises_warns_and_returns_collected(self, tmp_path, mock_logger):
+        handler = _handler(tmp_path)
+        client = MagicMock()
+        client.api.dcim.interfaces.filter.side_effect = Exception("boom")
+
+        result = handler._get_physical_uplink_interfaces(
+            make_device(1, "metalbox"), client
+        )
+
+        assert result == []
+        mock_logger.warning.assert_called_once()
+
+
+class TestGetDhcpOptionsRouted:
+    def test_three_options_per_prefix_with_gateway(self, tmp_path):
+        handler = _handler(tmp_path)
+        mapping = handler._build_prefix_tag_mapping(
+            [make_prefix("192.0.2.0/24", vlan=make_vlan(100))]
+        )
+        options = handler._get_dhcp_options_routed("192.0.2.254", mapping)
+        assert options == [
+            "tag:vlan100,3,192.0.2.1",
+            "tag:vlan100,6,192.0.2.254",
+            "tag:vlan100,42,192.0.2.254",
+        ]
+
+
+class TestGetDynamicHostsRouted:
+    def test_exact_two_entries(self, tmp_path):
+        handler = _handler(tmp_path)
+        assert handler._get_dynamic_hosts_routed("192.0.2.254", "oob0") == [
+            "metalbox,192.0.2.254,oob0",
+            "metalbox.osism.xyz,192.0.2.254,oob0",
+        ]


### PR DESCRIPTION
Closes #551

Adds tier 6 (dnsmasq) unit tests for the `files/netbox/dnsmasq/` package
and the conftest factories they need. **Test-only change — no
`files/netbox/**` source is touched.** Tests drive a `MagicMock`-backed
fake `NetBoxClient` (whose `.api` is `make_fake_api(...)`) and write into
pytest's `tmp_path` as the inventory root, asserting on the real temp
tree and on collaborator `call_args`.

## Change set, in commit order

1. **Add dnsmasq test factories to netbox conftest** — adds
   `make_iface_type` / `make_vlan` / `make_vlan_group` / `make_prefix` /
   `make_dnsmasq_config`, extends `make_device` (`device_type=`),
   `make_interface` (`type`/`label`/`name`/`untagged_vlan`/
   `connected_endpoints`/`enabled`, `mgmt_only` now defaulted) and
   `make_fake_api` (`prefixes=` backing `ipam.prefixes.filter(tag=...)`).
   Every addition is keyword-only and defaulted; tier 1-3 tests pass
   unchanged.
2. **dhcp_config** — host-entry formatting, MAC-entry priority chain,
   `write_dhcp_ranges` filesystem output under `tmp_path`.
3. **base** — `write_dnsmasq_to_device` across the four host_vars glob
   shapes (existing-dir / existing-file-append / new-dir / multi-match).
4. **interface_handler** — the static `get_virtual_interfaces_for_dnsmasq`
   gating.
5. **manager_mode** — `process_devices` / `process_devices_readonly`.
6. **manager** — `write_dnsmasq_config` mode dispatch and
   `write_dnsmasq_dhcp_ranges` pass-through.
7. **metalbox_mode Part 1** — pure / single-interface helpers.
8. **metalbox_mode Part 2** — the collectors plus focused bridged /
   routed / switch-tracking `process_devices` scenarios.

## Verification

- `pytest tests/unit` — 377 passed (259 pre-existing netbox tests
  unchanged + 118 new tier-6 tests).
- `pytest tests/unit/netbox --cov=dnsmasq` — 98% package coverage; all
  six modules covered, every branch listed in the issue exercised. The
  few remaining uncovered lines are defensive `except`/guard blocks not
  enumerated in the issue (covering them would require contrived mocks
  that do not reflect real NetBox behaviour).
- `flake8` and `black --check` green on every touched file.

## Deviation from the issue

The issue declares dependencies on #546 (tier 4) and #550 (tier 5), but
neither is merged to `main` yet — they exist only as unmerged branches.
Tier 6's interface/VLAN tests need their factories (`make_vlan`,
`make_iface_type`, the extended `make_interface`), so this PR ports the
minimal necessary factory shapes into the conftest itself (the fallback
the planning session anticipated) rather than blocking on the dependency
merge. All additions are backward compatible. If #546/#550 land first,
the overlapping factory definitions should be reconciled at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
