### PR TITLE
Use pull_request_target so fork PRs get added to project boards

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
Fork PRs trigger the `pull_request` event without access to secrets, so
`secrets: inherit` passes an empty `ADD_TO_PROJECT_PAT` and
`actions/add-to-project` fails with a missing github-token.

`pull_request_target` runs in the base-repository context where secrets are
available. It is safe here because this workflow never checks out or executes
PR code — it only calls `actions/add-to-project`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)